### PR TITLE
RST_817_throttle_identical_log

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -43,6 +43,7 @@ except ImportError:
     import pickle
 import inspect
 import logging
+from md5 import md5
 import os
 import signal
 import sys
@@ -151,6 +152,7 @@ def _base_logger(msg, *args, **kwargs):
     throttle = kwargs.pop('logger_throttle', None)
     level = kwargs.pop('logger_level', None)
     once = kwargs.pop('logger_once', False)
+    throttle_identical = kwargs.pop('logger_throttle_identical', False)
 
     rospy_logger = logging.getLogger('rosout')
     if name:
@@ -160,6 +162,13 @@ def _base_logger(msg, *args, **kwargs):
     if once:
         caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
         if _logging_once(caller_id):
+            logfunc(msg, *args)
+    elif throttle_identical:
+        caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
+        throttle_elapsed = False
+        if throttle is not None:
+            throttle_elapsed = _logging_throttle(caller_id, throttle)
+        if _logging_identical(caller_id, msg) or throttle_elapsed:
             logfunc(msg, *args)
     elif throttle:
         caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
@@ -213,6 +222,27 @@ class LoggingThrottle(object):
 
 
 _logging_throttle = LoggingThrottle()
+
+
+class LoggingIdentical(object):
+
+    last_logging_msg_table = {}
+
+    def __call__(self, caller_id, msg):
+        """Do logging specified message only if distinct from last message.
+
+        - caller_id (str): Id to identify the caller
+        - msg (str): Contents of message to log
+        """
+        msg_hash = md5(msg).hexdigest()
+
+        if msg_hash != self.last_logging_msg_table.get(caller_id):
+            self.last_logging_msg_table[caller_id] = msg_hash
+            return True
+        return False
+
+
+_logging_identical = LoggingIdentical()
 
 
 def _frame_to_caller_id(frame):
@@ -595,4 +625,3 @@ def xmlrpcapi(uri):
     if not uriValidate[0] or not uriValidate[1]:
         return None
     return xmlrpcclient.ServerProxy(uri)
-


### PR DESCRIPTION
adds the unique logger kwarg to rospy logs.

This causes a logger to publish if either:
1. New message does not match the previous message
2. Throttling is set and throttle period has elapsed

The awkward removal of whitespace is automated by Atom. is there an easy way to stop this from occuring? should i remove from this pr?