### PR TITLE
Replace md5 with hashlib

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -43,7 +43,7 @@ except ImportError:
     import pickle
 import inspect
 import logging
-from md5 import md5
+from hashlib import md5
 import os
 import signal
 import sys


### PR DESCRIPTION
Hashlib is deprecated in python2.5, and removed in python3