### PR TITLE
Repeat latched messages at start of bag

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -98,6 +98,7 @@ struct ROSBAG_DECL RecorderOptions
     bool            snapshot;
     bool            verbose;
     bool            publish;
+    bool            repeat_latched;
     CompressionType compression;
     std::string     prefix;
     std::string     name;
@@ -169,6 +170,8 @@ private:
     int                           num_subscribers_;      //!< used for book-keeping of our number of subscribers
 
     int                           exit_code_;            //!< eventual exit code
+
+    std::map<std::pair<std::string, std::string>, OutgoingMessage> latched_msgs_;
 
     boost::condition_variable_any queue_condition_;      //!< conditional variable for queue
     boost::mutex                  queue_mutex_;          //!< mutex for queue

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -69,15 +69,16 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")
       ("node", po::value<std::string>(), "Record all topics subscribed to by a specific node.")
       ("tcpnodelay", "Use the TCP_NODELAY transport hint when subscribing to topics.")
-      ("udp", "Use the UDP transport hint when subscribing to topics.");
+      ("udp", "Use the UDP transport hint when subscribing to topics.")
+      ("repeat-latched", "Repeat latched msgs at the start of each new bag file.");
 
-  
+
     po::positional_options_description p;
     p.add("topic", -1);
-    
+
     po::variables_map vm;
-    
-    try 
+
+    try
     {
       po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     } catch (boost::program_options::invalid_command_line_syntax& e)
@@ -106,6 +107,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       opts.quiet = true;
     if (vm.count("publish"))
       opts.publish = true;
+    if (vm.count("repeat-latched"))
+      opts.repeat_latched = true;
     if (vm.count("output-prefix"))
     {
       opts.prefix = vm["output-prefix"].as<std::string>();
@@ -227,7 +230,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       else
         throw ros::Exception("Duration unit must be s, m, or h");
 
-      
+
       opts.max_duration = ros::Duration(duration * multiplier);
       if (opts.max_duration <= ros::Duration(0))
         throw ros::Exception("Duration must be positive.");
@@ -296,6 +299,6 @@ int main(int argc, char** argv) {
     // Run the recorder
     rosbag::Recorder recorder(opts);
     int result = recorder.run();
-    
+
     return result;
 }

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -75,10 +75,10 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
     po::positional_options_description p;
     p.add("topic", -1);
-
+    
     po::variables_map vm;
-
-    try
+    
+    try 
     {
       po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     } catch (boost::program_options::invalid_command_line_syntax& e)
@@ -230,7 +230,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       else
         throw ros::Exception("Duration unit must be s, m, or h");
 
-
+      
       opts.max_duration = ros::Duration(duration * multiplier);
       if (opts.max_duration <= ros::Duration(0))
         throw ros::Exception("Duration must be positive.");
@@ -299,6 +299,6 @@ int main(int argc, char** argv) {
     // Run the recorder
     rosbag::Recorder recorder(opts);
     int result = recorder.run();
-
+    
     return result;
 }

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -251,7 +251,7 @@ bool Recorder::shouldSubscribeToTopic(std::string const& topic, bool from_node) 
     if(options_.record_all || from_node) {
         return true;
     }
-    
+
     if (options_.regex) {
         // Treat the topics as regular expressions
 	return std::any_of(
@@ -285,18 +285,31 @@ std::string Recorder::timeToStr(T ros_t)
 void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
     //void Recorder::doQueue(topic_tools::ShapeShifter::ConstPtr msg, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
     Time rectime = Time::now();
-    
+
     if (options_.verbose)
         cout << "Received message on topic " << subscriber->getTopic() << endl;
 
     OutgoingMessage out(topic, msg_event.getMessage(), msg_event.getConnectionHeaderPtr(), rectime);
-    
+
     {
         boost::mutex::scoped_lock lock(queue_mutex_);
 
         queue_->push(out);
         queue_size_ += out.msg->size();
-        
+
+        if (options_.repeat_latched)
+        {
+            ros::M_string::const_iterator it = out.connection_header->find("latching");
+            if ((it != out.connection_header->end()) && (it->second == "1"))
+            {
+                ros::M_string::const_iterator it2 = out.connection_header->find("callerid");
+                if (it2 != out.connection_header->end())
+                {
+                    latched_msgs_.insert({{subscriber->getTopic(), it2->second}, out});
+                }
+            }
+        }
+
         // Check to see if buffer has been exceeded
         while (options_.buffer_size > 0 && queue_size_ > options_.buffer_size) {
             OutgoingMessage drop = queue_->front();
@@ -312,7 +325,7 @@ void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>&
             }
         }
     }
-  
+
     if (!options_.snapshot)
         queue_condition_.notify_all();
 
@@ -365,9 +378,9 @@ void Recorder::updateFilenames() {
 void Recorder::snapshotTrigger(std_msgs::Empty::ConstPtr trigger) {
     (void)trigger;
     updateFilenames();
-    
+
     ROS_INFO("Triggered snapshot recording with name %s.", target_filename_.c_str());
-    
+
     {
         boost::mutex::scoped_lock lock(queue_mutex_);
         queue_queue_.push(OutgoingQueue(target_filename_, queue_, Time::now()));
@@ -392,6 +405,15 @@ void Recorder::startWriting() {
         ros::shutdown();
     }
     ROS_INFO("Recording to %s.", target_filename_.c_str());
+
+    if (options_.repeat_latched)
+    {
+        // Start each new bag file with copies of all latched messages.
+        for (auto const& out : latched_msgs_)
+        {
+            bag_.write(out.second.topic, out.second.time, *out.second.msg);
+        }
+    }
 
     if (options_.publish)
     {
@@ -527,9 +549,9 @@ void Recorder::doRecord() {
         OutgoingMessage out = queue_->front();
         queue_->pop();
         queue_size_ -= out.msg->size();
-        
+
         lock.release()->unlock();
-        
+
         if (checkSize())
             break;
 
@@ -554,7 +576,7 @@ void Recorder::doRecord() {
 
 void Recorder::doRecordSnapshotter() {
     ros::NodeHandle nh;
-  
+
     while (nh.ok() || !queue_queue_.empty()) {
         boost::unique_lock<boost::mutex> lock(queue_mutex_);
         while (queue_queue_.empty()) {
@@ -562,15 +584,15 @@ void Recorder::doRecordSnapshotter() {
                 return;
             queue_condition_.wait(lock);
         }
-        
+
         OutgoingQueue out_queue = queue_queue_.front();
         queue_queue_.pop();
-        
+
         lock.release()->unlock();
-        
+
         string target_filename = out_queue.filename;
         string write_filename  = target_filename + string(".active");
-        
+
         try {
             bag_.open(write_filename, bagmode::Write);
         }
@@ -600,7 +622,7 @@ void Recorder::doCheckMaster(ros::TimerEvent const& e, ros::NodeHandle& node_han
 	        subscribe(t.name);
 	}
     }
-    
+
     if (options_.node != std::string(""))
     {
 
@@ -625,7 +647,7 @@ void Recorder::doCheckMaster(ros::TimerEvent const& e, ros::NodeHandle& node_han
           XmlRpc::XmlRpcValue resp2;
           req2[0] = ros::this_node::getName();
           c.execute("getSubscriptions", req2, resp2);
-          
+
           if (!c.isFault() && resp2.valid() && resp2.size() > 0 && static_cast<int>(resp2[0]) == 1)
           {
             for(int i = 0; i < resp2[2].size(); i++)
@@ -692,8 +714,8 @@ bool Recorder::checkDisk() {
     {
         info = boost::filesystem::space(p);
     }
-    catch (boost::filesystem::filesystem_error &e) 
-    { 
+    catch (boost::filesystem::filesystem_error &e)
+    {
         ROS_WARN("Failed to check filesystem stats [%s].", e.what());
         writing_enabled_ = false;
         return false;

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -251,7 +251,7 @@ bool Recorder::shouldSubscribeToTopic(std::string const& topic, bool from_node) 
     if(options_.record_all || from_node) {
         return true;
     }
-
+    
     if (options_.regex) {
         // Treat the topics as regular expressions
 	return std::any_of(
@@ -285,12 +285,12 @@ std::string Recorder::timeToStr(T ros_t)
 void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
     //void Recorder::doQueue(topic_tools::ShapeShifter::ConstPtr msg, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
     Time rectime = Time::now();
-
+    
     if (options_.verbose)
         cout << "Received message on topic " << subscriber->getTopic() << endl;
 
     OutgoingMessage out(topic, msg_event.getMessage(), msg_event.getConnectionHeaderPtr(), rectime);
-
+    
     {
         boost::mutex::scoped_lock lock(queue_mutex_);
 
@@ -325,7 +325,7 @@ void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>&
             }
         }
     }
-
+  
     if (!options_.snapshot)
         queue_condition_.notify_all();
 
@@ -378,9 +378,9 @@ void Recorder::updateFilenames() {
 void Recorder::snapshotTrigger(std_msgs::Empty::ConstPtr trigger) {
     (void)trigger;
     updateFilenames();
-
+    
     ROS_INFO("Triggered snapshot recording with name %s.", target_filename_.c_str());
-
+    
     {
         boost::mutex::scoped_lock lock(queue_mutex_);
         queue_queue_.push(OutgoingQueue(target_filename_, queue_, Time::now()));
@@ -549,9 +549,9 @@ void Recorder::doRecord() {
         OutgoingMessage out = queue_->front();
         queue_->pop();
         queue_size_ -= out.msg->size();
-
+        
         lock.release()->unlock();
-
+        
         if (checkSize())
             break;
 
@@ -576,7 +576,7 @@ void Recorder::doRecord() {
 
 void Recorder::doRecordSnapshotter() {
     ros::NodeHandle nh;
-
+  
     while (nh.ok() || !queue_queue_.empty()) {
         boost::unique_lock<boost::mutex> lock(queue_mutex_);
         while (queue_queue_.empty()) {
@@ -584,15 +584,15 @@ void Recorder::doRecordSnapshotter() {
                 return;
             queue_condition_.wait(lock);
         }
-
+        
         OutgoingQueue out_queue = queue_queue_.front();
         queue_queue_.pop();
-
+        
         lock.release()->unlock();
-
+        
         string target_filename = out_queue.filename;
         string write_filename  = target_filename + string(".active");
-
+        
         try {
             bag_.open(write_filename, bagmode::Write);
         }
@@ -622,7 +622,7 @@ void Recorder::doCheckMaster(ros::TimerEvent const& e, ros::NodeHandle& node_han
 	        subscribe(t.name);
 	}
     }
-
+    
     if (options_.node != std::string(""))
     {
 
@@ -647,7 +647,7 @@ void Recorder::doCheckMaster(ros::TimerEvent const& e, ros::NodeHandle& node_han
           XmlRpc::XmlRpcValue resp2;
           req2[0] = ros::this_node::getName();
           c.execute("getSubscriptions", req2, resp2);
-
+          
           if (!c.isFault() && resp2.valid() && resp2.size() > 0 && static_cast<int>(resp2[0]) == 1)
           {
             for(int i = 0; i < resp2[2].size(); i++)
@@ -714,8 +714,8 @@ bool Recorder::checkDisk() {
     {
         info = boost::filesystem::space(p);
     }
-    catch (boost::filesystem::filesystem_error &e)
-    {
+    catch (boost::filesystem::filesystem_error &e) 
+    { 
         ROS_WARN("Failed to check filesystem stats [%s].", e.what());
         writing_enabled_ = false;
         return false;

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -189,7 +189,7 @@ def info_cmd(argv):
             b.close()
             if i < len(args) - 1:
                 print('---')
-
+        
         except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
             print('ERROR: %s' % str(ex), file=sys.stderr)
         except ROSBagUnindexedException as ex:
@@ -355,7 +355,7 @@ The following variables are available:
     filter_fn = expr_eval(expr)
 
     outbag = Bag(outbag_filename, 'w')
-
+    
     try:
         inbag = Bag(inbag_filename)
     except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
@@ -368,10 +368,10 @@ The following variables are available:
     try:
         meter = ProgressMeter(outbag_filename, inbag._uncompressed_size)
         total_bytes = 0
-
+    
         if options.verbose_pattern:
             verbose_pattern = expr_eval(options.verbose_pattern)
-
+    
             for topic, raw_msg, t, conn_header in inbag.read_messages(raw=True, return_connection_header=True):
                 msg_type, serialized_bytes, md5sum, pos, pytype = raw_msg
                 msg = pytype()
@@ -381,7 +381,7 @@ The following variables are available:
                     print('MATCH', verbose_pattern(topic, msg, t))
                     outbag.write(topic, msg, t, connection_header=conn_header)
                 else:
-                    print('NO MATCH', verbose_pattern(topic, msg, t))
+                    print('NO MATCH', verbose_pattern(topic, msg, t))          
 
                 total_bytes += len(serialized_bytes)
                 meter.step(total_bytes)
@@ -396,7 +396,7 @@ The following variables are available:
 
                 total_bytes += len(serialized_bytes)
                 meter.step(total_bytes)
-
+        
         meter.finish()
 
     finally:
@@ -417,7 +417,7 @@ def fix_cmd(argv):
 
     inbag_filename  = args[0]
     outbag_filename = args[1]
-    rules           = args[2:]
+    rules           = args[2:]   
 
     ext = os.path.splitext(outbag_filename)[1]
     if ext == '.bmr':
@@ -455,7 +455,7 @@ def fix_cmd(argv):
         options.noplugins = False
 
     migrator = MessageMigrator(rules, plugins=not options.noplugins)
-
+    
     try:
         migrations = fixbag2(migrator, inbag_filename, outname, options.force)
     except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
@@ -473,12 +473,12 @@ def fix_cmd(argv):
         print('Bag could not be migrated.  The following migrations could not be performed:')
         for m in migrations:
             print_trans(m[0][0].old_class, m[0][-1].new_class, 0)
-
+            
             if len(m[1]) > 0:
                 print('    %d rules missing:' % len(m[1]))
                 for r in m[1]:
                     print_trans(r.old_class, r.new_class,1)
-
+                    
         print('Try running \'rosbag check\' to create the necessary rule files or run \'rosbag fix\' with the \'--force\' option.')
         os.remove(outname)
         sys.exit(1)
@@ -500,13 +500,13 @@ def check_cmd(argv):
             parser.error('The file %s already exists.  Include -a if you intend to append.' % options.rulefile)
         if not rulefile_exists and options.append:
             parser.error('The file %s does not exist, and so -a is invalid.' % options.rulefile)
-
+    
     if options.append:
         append_rule = [options.rulefile]
     else:
         append_rule = []
 
-    # First check that the bag is not unindexed
+    # First check that the bag is not unindexed 
     try:
         Bag(args[0])
     except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
@@ -517,13 +517,13 @@ def check_cmd(argv):
         sys.exit(1)
 
     mm = MessageMigrator(args[1:] + append_rule, not options.noplugins)
-
+       
     migrations = checkbag(mm, args[0])
 
     if len(migrations) == 0:
         print('Bag file does not need any migrations.')
         exit(0)
-
+        
     print('The following migrations need to occur:')
     all_rules = []
     for m in migrations:
@@ -606,9 +606,9 @@ def decompress_cmd(argv):
 
     if len(args) < 1:
         parser.error('You must specify at least one bag file.')
-
+    
     op = lambda inbag, outbag, quiet: change_compression_op(inbag, outbag, Compression.NONE, options.quiet)
-
+    
     bag_op(args, False, True, lambda b: False, op, options.output_dir, options.force, options.quiet)
 
 def reindex_cmd(argv):
@@ -622,7 +622,7 @@ def reindex_cmd(argv):
 
     if len(args) < 1:
         parser.error('You must specify at least one bag file.')
-
+    
     op = lambda inbag, outbag, quiet: reindex_op(inbag, outbag, options.quiet)
 
     bag_op(args, True, True, lambda b: b.version > 102, op, options.output_dir, options.force, options.quiet)
@@ -693,12 +693,12 @@ def bag_op(inbag_filenames, allow_unindexed, open_inbag, copy_fn, op, output_dir
         if outbag_filename == inbag_filename:
             # Rename the input bag to ###.orig.###, and open for reading
             backup_filename = '%s.orig%s' % os.path.splitext(inbag_filename)
-
+            
             if not force and os.path.exists(backup_filename):
                 if not quiet:
                     print('Skipping %s. Backup path %s already exists.' % (inbag_filename, backup_filename), file=sys.stderr)
                 continue
-
+            
             try:
                 if copy:
                     shutil.copy(inbag_filename, backup_filename)
@@ -707,7 +707,7 @@ def bag_op(inbag_filenames, allow_unindexed, open_inbag, copy_fn, op, output_dir
             except OSError as ex:
                 print('ERROR %s %s to %s: %s' % ('copying' if copy else 'moving', inbag_filename, backup_filename, str(ex)), file=sys.stderr)
                 continue
-
+            
             source_filename = backup_filename
         else:
             if copy:
@@ -773,7 +773,7 @@ def bag_op(inbag_filenames, allow_unindexed, open_inbag, copy_fn, op, output_dir
                 except OSError as ex:
                     print('ERROR %s %s to %s: %s', ('removing' if copy else 'moving', backup_filename, inbag_filename, str(ex)), file=sys.stderr)
                     break
-
+    
         except (ROSBagException, IOError) as ex:
             print('ERROR operating on %s: %s' % (inbag_filename, str(ex)), file=sys.stderr)
 
@@ -789,12 +789,12 @@ def change_compression_op(inbag, outbag, compression, quiet):
         total_bytes = 0
         for topic, msg, t, conn_header in inbag.read_messages(raw=True, return_connection_header=True):
             msg_type, serialized_bytes, md5sum, pos, pytype = msg
-
+    
             outbag.write(topic, msg, t, raw=True, connection_header=conn_header)
-
-            total_bytes += len(serialized_bytes)
+            
+            total_bytes += len(serialized_bytes) 
             meter.step(total_bytes)
-
+        
         meter.finish()
 
 def reindex_op(inbag, outbag, quiet):
@@ -881,7 +881,7 @@ class RosbagCmds(UserDict):
     def add_cmd(self, name, function, description):
         self[name] = function
         self._description[name] = description
-
+        
     def get_valid_cmds(self):
         str = "Available subcommands:\n"
         for k in sorted(self.keys()):
@@ -916,7 +916,7 @@ class ProgressMeter(object):
         self.path           = path
         self.bytes_total    = bytes_total
         self.refresh_rate   = refresh_rate
-
+        
         self.elapsed        = 0.0
         self.update_elapsed = 0.0
         self.bytes_read     = 0.0
@@ -928,7 +928,7 @@ class ProgressMeter(object):
     def step(self, bytes_read, force_update=False):
         self.bytes_read = bytes_read
         self.elapsed    = time.time() - self.start_time
-
+        
         if force_update or self.elapsed - self.update_elapsed > self.refresh_rate:
             self._update_progress()
             self.update_elapsed = self.elapsed
@@ -941,7 +941,7 @@ class ProgressMeter(object):
 
         bytes_read_str  = self._human_readable_size(float(self.bytes_read))
         bytes_total_str = self._human_readable_size(float(self.bytes_total))
-
+        
         if self.bytes_read < self.bytes_total:
             complete_fraction = float(self.bytes_read) / self.bytes_total
             pct_complete      = int(100.0 * complete_fraction)
@@ -962,14 +962,14 @@ class ProgressMeter(object):
 
         print('\r', progress, end='')
         sys.stdout.flush()
-
+        
     def _human_readable_size(self, size):
         multiple = 1024.0
         for suffix in ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']:
             size /= multiple
             if size < multiple:
                 return '%.1f %s' % (size, suffix)
-
+    
         raise ValueError('number too large')
 
     def finish(self):
@@ -994,7 +994,7 @@ class ProgressMeter(object):
                 pass
         if width <= 0:
             width = 80
-
+    
         return width
 
 def rosbagmain(argv=None):

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -96,6 +96,7 @@ def record_cmd(argv):
     parser.add_option("--lz4",                 dest="compression",                  action="store_const", const='lz4', help="use LZ4 compression")
     parser.add_option("--tcpnodelay",          dest="tcpnodelay",                   action="store_true",          help="Use the TCP_NODELAY transport hint when subscribing to topics.")
     parser.add_option("--udp",                 dest="udp",                          action="store_true",          help="Use the UDP transport hint when subscribing to topics.")
+    parser.add_option("--repeat-latched",      dest="repeat_latched",               action="store_true",          help="Repeat latched msgs at the start of each new bag file.")
 
     (options, args) = parser.parse_args(argv)
 
@@ -134,6 +135,7 @@ def record_cmd(argv):
         cmd.extend(["--node", options.node])
     if options.tcpnodelay:  cmd.extend(["--tcpnodelay"])
     if options.udp:         cmd.extend(["--udp"])
+    if options.repeat_latched:  cmd.extend(["--repeat-latched"])
 
     cmd.extend(args)
 
@@ -187,7 +189,7 @@ def info_cmd(argv):
             b.close()
             if i < len(args) - 1:
                 print('---')
-        
+
         except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
             print('ERROR: %s' % str(ex), file=sys.stderr)
         except ROSBagUnindexedException as ex:
@@ -353,7 +355,7 @@ The following variables are available:
     filter_fn = expr_eval(expr)
 
     outbag = Bag(outbag_filename, 'w')
-    
+
     try:
         inbag = Bag(inbag_filename)
     except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
@@ -366,10 +368,10 @@ The following variables are available:
     try:
         meter = ProgressMeter(outbag_filename, inbag._uncompressed_size)
         total_bytes = 0
-    
+
         if options.verbose_pattern:
             verbose_pattern = expr_eval(options.verbose_pattern)
-    
+
             for topic, raw_msg, t, conn_header in inbag.read_messages(raw=True, return_connection_header=True):
                 msg_type, serialized_bytes, md5sum, pos, pytype = raw_msg
                 msg = pytype()
@@ -379,9 +381,9 @@ The following variables are available:
                     print('MATCH', verbose_pattern(topic, msg, t))
                     outbag.write(topic, msg, t, connection_header=conn_header)
                 else:
-                    print('NO MATCH', verbose_pattern(topic, msg, t))          
+                    print('NO MATCH', verbose_pattern(topic, msg, t))
 
-                total_bytes += len(serialized_bytes) 
+                total_bytes += len(serialized_bytes)
                 meter.step(total_bytes)
         else:
             for topic, raw_msg, t, conn_header in inbag.read_messages(raw=True, return_connection_header=True):
@@ -394,7 +396,7 @@ The following variables are available:
 
                 total_bytes += len(serialized_bytes)
                 meter.step(total_bytes)
-        
+
         meter.finish()
 
     finally:
@@ -415,7 +417,7 @@ def fix_cmd(argv):
 
     inbag_filename  = args[0]
     outbag_filename = args[1]
-    rules           = args[2:]   
+    rules           = args[2:]
 
     ext = os.path.splitext(outbag_filename)[1]
     if ext == '.bmr':
@@ -453,7 +455,7 @@ def fix_cmd(argv):
         options.noplugins = False
 
     migrator = MessageMigrator(rules, plugins=not options.noplugins)
-    
+
     try:
         migrations = fixbag2(migrator, inbag_filename, outname, options.force)
     except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
@@ -471,12 +473,12 @@ def fix_cmd(argv):
         print('Bag could not be migrated.  The following migrations could not be performed:')
         for m in migrations:
             print_trans(m[0][0].old_class, m[0][-1].new_class, 0)
-            
+
             if len(m[1]) > 0:
                 print('    %d rules missing:' % len(m[1]))
                 for r in m[1]:
                     print_trans(r.old_class, r.new_class,1)
-                    
+
         print('Try running \'rosbag check\' to create the necessary rule files or run \'rosbag fix\' with the \'--force\' option.')
         os.remove(outname)
         sys.exit(1)
@@ -498,13 +500,13 @@ def check_cmd(argv):
             parser.error('The file %s already exists.  Include -a if you intend to append.' % options.rulefile)
         if not rulefile_exists and options.append:
             parser.error('The file %s does not exist, and so -a is invalid.' % options.rulefile)
-    
+
     if options.append:
         append_rule = [options.rulefile]
     else:
         append_rule = []
 
-    # First check that the bag is not unindexed 
+    # First check that the bag is not unindexed
     try:
         Bag(args[0])
     except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
@@ -517,11 +519,11 @@ def check_cmd(argv):
     mm = MessageMigrator(args[1:] + append_rule, not options.noplugins)
 
     migrations = checkbag(mm, args[0])
-       
+
     if len(migrations) == 0:
         print('Bag file does not need any migrations.')
         exit(0)
-        
+
     print('The following migrations need to occur:')
     all_rules = []
     for m in migrations:
@@ -604,9 +606,9 @@ def decompress_cmd(argv):
 
     if len(args) < 1:
         parser.error('You must specify at least one bag file.')
-    
+
     op = lambda inbag, outbag, quiet: change_compression_op(inbag, outbag, Compression.NONE, options.quiet)
-    
+
     bag_op(args, False, True, lambda b: False, op, options.output_dir, options.force, options.quiet)
 
 def reindex_cmd(argv):
@@ -620,7 +622,7 @@ def reindex_cmd(argv):
 
     if len(args) < 1:
         parser.error('You must specify at least one bag file.')
-    
+
     op = lambda inbag, outbag, quiet: reindex_op(inbag, outbag, options.quiet)
 
     bag_op(args, True, True, lambda b: b.version > 102, op, options.output_dir, options.force, options.quiet)
@@ -691,12 +693,12 @@ def bag_op(inbag_filenames, allow_unindexed, open_inbag, copy_fn, op, output_dir
         if outbag_filename == inbag_filename:
             # Rename the input bag to ###.orig.###, and open for reading
             backup_filename = '%s.orig%s' % os.path.splitext(inbag_filename)
-            
+
             if not force and os.path.exists(backup_filename):
                 if not quiet:
                     print('Skipping %s. Backup path %s already exists.' % (inbag_filename, backup_filename), file=sys.stderr)
                 continue
-            
+
             try:
                 if copy:
                     shutil.copy(inbag_filename, backup_filename)
@@ -705,7 +707,7 @@ def bag_op(inbag_filenames, allow_unindexed, open_inbag, copy_fn, op, output_dir
             except OSError as ex:
                 print('ERROR %s %s to %s: %s' % ('copying' if copy else 'moving', inbag_filename, backup_filename, str(ex)), file=sys.stderr)
                 continue
-            
+
             source_filename = backup_filename
         else:
             if copy:
@@ -771,7 +773,7 @@ def bag_op(inbag_filenames, allow_unindexed, open_inbag, copy_fn, op, output_dir
                 except OSError as ex:
                     print('ERROR %s %s to %s: %s', ('removing' if copy else 'moving', backup_filename, inbag_filename, str(ex)), file=sys.stderr)
                     break
-    
+
         except (ROSBagException, IOError) as ex:
             print('ERROR operating on %s: %s' % (inbag_filename, str(ex)), file=sys.stderr)
 
@@ -787,12 +789,12 @@ def change_compression_op(inbag, outbag, compression, quiet):
         total_bytes = 0
         for topic, msg, t, conn_header in inbag.read_messages(raw=True, return_connection_header=True):
             msg_type, serialized_bytes, md5sum, pos, pytype = msg
-    
+
             outbag.write(topic, msg, t, raw=True, connection_header=conn_header)
-            
-            total_bytes += len(serialized_bytes) 
+
+            total_bytes += len(serialized_bytes)
             meter.step(total_bytes)
-        
+
         meter.finish()
 
 def reindex_op(inbag, outbag, quiet):
@@ -879,7 +881,7 @@ class RosbagCmds(UserDict):
     def add_cmd(self, name, function, description):
         self[name] = function
         self._description[name] = description
-        
+
     def get_valid_cmds(self):
         str = "Available subcommands:\n"
         for k in sorted(self.keys()):
@@ -914,7 +916,7 @@ class ProgressMeter(object):
         self.path           = path
         self.bytes_total    = bytes_total
         self.refresh_rate   = refresh_rate
-        
+
         self.elapsed        = 0.0
         self.update_elapsed = 0.0
         self.bytes_read     = 0.0
@@ -926,7 +928,7 @@ class ProgressMeter(object):
     def step(self, bytes_read, force_update=False):
         self.bytes_read = bytes_read
         self.elapsed    = time.time() - self.start_time
-        
+
         if force_update or self.elapsed - self.update_elapsed > self.refresh_rate:
             self._update_progress()
             self.update_elapsed = self.elapsed
@@ -939,7 +941,7 @@ class ProgressMeter(object):
 
         bytes_read_str  = self._human_readable_size(float(self.bytes_read))
         bytes_total_str = self._human_readable_size(float(self.bytes_total))
-        
+
         if self.bytes_read < self.bytes_total:
             complete_fraction = float(self.bytes_read) / self.bytes_total
             pct_complete      = int(100.0 * complete_fraction)
@@ -960,14 +962,14 @@ class ProgressMeter(object):
 
         print('\r', progress, end='')
         sys.stdout.flush()
-        
+
     def _human_readable_size(self, size):
         multiple = 1024.0
         for suffix in ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']:
             size /= multiple
             if size < multiple:
                 return '%.1f %s' % (size, suffix)
-    
+
         raise ValueError('number too large')
 
     def finish(self):
@@ -992,7 +994,7 @@ class ProgressMeter(object):
                 pass
         if width <= 0:
             width = 80
-    
+
         return width
 
 def rosbagmain(argv=None):


### PR DESCRIPTION
Adds a --repeat-latched option to `rosbag record`. This makes `Recorder` maintain a {(topic, publisher):  message} map, then iterate over that map for each new bagfile. In theory this could cause problems if the total size of latched messages exceeds the max size of the bag, if that seems like a reasonable cause for concern I can skip writing latched messages if the total size of the map gets too large.