### PR TITLE
Fix latched timestamps

### DIFF
--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -409,9 +409,12 @@ void Recorder::startWriting() {
     if (options_.repeat_latched)
     {
         // Start each new bag file with copies of all latched messages.
+        ros::Time now = ros::Time::now();
         for (auto const& out : latched_msgs_)
         {
-            bag_.write(out.second.topic, out.second.time, *out.second.msg);
+            // Overwrite the original receipt time, otherwise the new bag will
+            // have a gap before the new messages start.
+            bag_.write(out.second.topic, now, *out.second.msg);
         }
     }
 

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -383,7 +383,7 @@ The following variables are available:
                 else:
                     print('NO MATCH', verbose_pattern(topic, msg, t))          
 
-                total_bytes += len(serialized_bytes)
+                total_bytes += len(serialized_bytes) 
                 meter.step(total_bytes)
         else:
             for topic, raw_msg, t, conn_header in inbag.read_messages(raw=True, return_connection_header=True):
@@ -519,7 +519,7 @@ def check_cmd(argv):
     mm = MessageMigrator(args[1:] + append_rule, not options.noplugins)
        
     migrations = checkbag(mm, args[0])
-
+       
     if len(migrations) == 0:
         print('Bag file does not need any migrations.')
         exit(0)


### PR DESCRIPTION
Currently, our --latched-repeat feature begins each new bag split with latched messages using their original receipt time, which causes problems on playback since there will be a long gap before the new data begins playing.

This PR now writes those messages using the current time (while leaving their headers, if any, intact).