### PR TITLE
Initialize publisher/subscriber options in impl constructors

### DIFF
--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -853,8 +853,6 @@ class Publisher(Topic):
         options = _TopicOptions()
         options.latch = latch
         options.tcp_nodelay = tcp_nodelay
-        #if tcp_nodelay:
-        #    get_tcpros_handler().set_tcp_nodelay(self.resolved_name, tcp_nodelay)
         if queue_size is not None:
             options.queue_size = queue_size
         else:


### PR DESCRIPTION
Prevents misconfigured connections from being added to a topic before
topic configuration is complete.