### PR TITLE
Transporthint tos

### DIFF
--- a/clients/roscpp/include/ros/transport/transport_tcp.h
+++ b/clients/roscpp/include/ros/transport/transport_tcp.h
@@ -99,6 +99,7 @@ public:
   int getServerPort() { return server_port_; }
   int getLocalPort() { return local_port_; }
 
+  void setTos(int tos);
   void setNoDelay(bool nodelay);
   void setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint32_t count);
 

--- a/clients/roscpp/include/ros/transport_hints.h
+++ b/clients/roscpp/include/ros/transport_hints.h
@@ -106,6 +106,31 @@ public:
   }
 
   /**
+   * \brief Set TOS level for traffic on this connection.
+   *
+   * \param ip_tos Level of TOS to set - see <netinet/ip.h>
+   */
+  TransportHints& ipTos(int ip_tos)
+  {
+    options_["ip_tos"] = boost::lexical_cast<string>(ip_tos);
+    return *this;
+  }
+
+  /**
+   * \brief Returns whether or not this TransportHints has specified IP_TOS level.
+   */
+  bool getIpTos()
+  {
+    M_string::iterator it = options_.find("ip_tos");
+    if (it == options_.end())
+    {
+      return 0;
+    }
+
+    return boost::lexical_cast<int>(it->second);
+  }
+
+  /**
    * \brief If a UDP transport is used, specifies the maximum datagram size.
    *
    * \param size The size, in bytes

--- a/clients/roscpp/include/ros/transport_hints.h
+++ b/clients/roscpp/include/ros/transport_hints.h
@@ -117,9 +117,10 @@ public:
   }
 
   /**
-   * \brief Returns whether or not this TransportHints has specified IP_TOS level.
+   * \brief Returns the IP_TOS level specified on this TransportHints, or 0 if
+   * no level was specified.
    */
-  bool getIpTos()
+  int getIpTos()
   {
     M_string::iterator it = options_.find("ip_tos");
     if (it == options_.end())

--- a/clients/roscpp/include/ros/transport_hints.h
+++ b/clients/roscpp/include/ros/transport_hints.h
@@ -32,6 +32,7 @@
 #include "ros/forwards.h"
 
 #include <boost/lexical_cast.hpp>
+#include <netinet/ip.h>
 
 namespace ros
 {
@@ -117,7 +118,7 @@ public:
   }
 
   /**
-   * \brief Returns the IP_TOS level specified on this TransportHints, or 0 if
+   * \brief Returns the IP_TOS level specified on this TransportHints, or CLASS_DEFAULT if
    * no level was specified.
    */
   int getIpTos()
@@ -125,7 +126,7 @@ public:
     M_string::iterator it = options_.find("ip_tos");
     if (it == options_.end())
     {
-      return 0;
+      return IPTOS_CLASS_DEFAULT;
     }
 
     return boost::lexical_cast<int>(it->second);

--- a/clients/roscpp/include/ros/transport_hints.h
+++ b/clients/roscpp/include/ros/transport_hints.h
@@ -112,7 +112,7 @@ public:
    */
   TransportHints& ipTos(int ip_tos)
   {
-    options_["ip_tos"] = boost::lexical_cast<string>(ip_tos);
+    options_["ip_tos"] = boost::lexical_cast<std::string>(ip_tos);
     return *this;
   }
 

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -42,6 +42,7 @@
 #include <boost/bind.hpp>
 #include <fcntl.h>
 #include <errno.h>
+
 namespace ros
 {
 
@@ -155,6 +156,23 @@ void TransportTCP::parseHeader(const Header& header)
   {
     ROSCPP_LOG_DEBUG("Setting nodelay on socket [%d]", sock_);
     setNoDelay(true);
+  }
+
+  std::string tos;
+  if (header.getValue("ip_tos", tos))
+  {
+    ROSCPP_LOG_DEBUG("Setting TOS on socket [%d]", sock_);
+    setTos(boost::lexical_cast<int>(tos));
+  }
+}
+
+void TransportTCP::setTos(int tos)
+{
+
+  int result = setsockopt(sock_, IPPROTO_TCP, IP_TOS, &flag, sizeof(flag));
+  if (result < 0)
+  {
+    ROS_ERROR("setsockopt failed to set TOS [%s] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
   }
 }
 

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -40,6 +40,7 @@
 #include <ros/assert.h>
 #include <sstream>
 #include <boost/bind.hpp>
+#include <boost/lexical_cast.hpp>
 #include <fcntl.h>
 #include <errno.h>
 
@@ -169,10 +170,10 @@ void TransportTCP::parseHeader(const Header& header)
 void TransportTCP::setTos(int tos)
 {
 
-  int result = setsockopt(sock_, IPPROTO_TCP, IP_TOS, &flag, sizeof(flag));
+  int result = setsockopt(sock_, IPPROTO_TCP, IP_TOS, &tos, sizeof(tos));
   if (result < 0)
   {
-    ROS_ERROR("setsockopt failed to set TOS [%s] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
+    ROS_ERROR("setsockopt failed to set TOS [%d] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
   }
 }
 

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -43,7 +43,6 @@
 #include <boost/lexical_cast.hpp>
 #include <fcntl.h>
 #include <errno.h>
-
 namespace ros
 {
 


### PR DESCRIPTION
Not much complexity here on the face of it but choosing the right value will be a pain. There are about 30 different options of varying degrees of deprecation hence I have just left the interface open ended. In our code we would want to do this for GS (other topics may use a different flag see <netinet/ip.h>):

```cpp
import <netinet/ip.h>
...

ros::TransportHints()
        .setTos(IPTOS_DSCP_EF);
```
<https://www.ietf.org/rfc/rfc2598.txt>

p.s. not touched C++ in what seems like forever so please forgive any dumb mistakes. I need to test it, all I can say right now is it compiles.