### PR TITLE
Transport hint fix debug

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -172,19 +172,10 @@ void TransportTCP::parseHeader(const Header& header)
 
 void TransportTCP::setTos(int tos)
 {
-  ROS_ERROR("Setting ip_tos to %d", tos);
   int result = setsockopt(sock_, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
   if (result < 0)
   {
     ROS_ERROR("setsockopt failed to set ip_tos [%d] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
-  }
-  int tos_val = 0;
-  socklen_t tos_len = sizeof(tos_val);
-
-  if (getsockopt(sock_, IPPROTO_IP, IP_TOS,  &tos_val, &tos_len) < 0) {
-    ROS_ERROR("getsockopt failed to get ip_tos");
-  } else {
-    ROS_ERROR("ip_tos set to %d on socket [%d] [%s]", tos_val, sock_, cached_remote_host_.c_str());
   }
 }
 

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -173,7 +173,7 @@ void TransportTCP::parseHeader(const Header& header)
 void TransportTCP::setTos(int tos)
 {
   ROS_ERROR("Setting ip_tos to %d", tos);
-  int result = setsockopt(sock_, IPPROTO_TCP, IP_TOS, &tos, sizeof(tos));
+  int result = setsockopt(sock_, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
   if (result < 0)
   {
     ROS_ERROR("setsockopt failed to set ip_tos [%d] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
@@ -181,7 +181,7 @@ void TransportTCP::setTos(int tos)
   int tos_val = 0;
   socklen_t tos_len = sizeof(tos_val);
 
-  if (getsockopt(sock_, IPPROTO_TCP, IP_TOS,  &tos_val, &tos_len) < 0) {
+  if (getsockopt(sock_, IPPROTO_IP, IP_TOS,  &tos_val, &tos_len) < 0) {
     ROS_ERROR("getsockopt failed to get ip_tos");
   } else {
     ROS_ERROR("ip_tos set to %d on socket [%d] [%s]", tos_val, sock_, cached_remote_host_.c_str());

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -163,20 +163,28 @@ void TransportTCP::parseHeader(const Header& header)
   }
 
   std::string tos;
-  if (header.getValue("ip_tos", tos))
+  if (header.getValue("ip_tos", tos) && tos != "0")
   {
-    ROSCPP_LOG_DEBUG("Setting TOS on socket [%d]", sock_);
+    ROSCPP_LOG_DEBUG("Setting TOS [%s] on socket [%d]", tos, sock_);
     setTos(boost::lexical_cast<int>(tos));
   }
 }
 
 void TransportTCP::setTos(int tos)
 {
-
+  ROS_ERROR("Setting ip_tos to %d", tos);
   int result = setsockopt(sock_, IPPROTO_TCP, IP_TOS, &tos, sizeof(tos));
   if (result < 0)
   {
-    ROS_ERROR("setsockopt failed to set TOS [%d] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
+    ROS_ERROR("setsockopt failed to set ip_tos [%d] on socket [%d] [%s]", tos, sock_, cached_remote_host_.c_str());
+  }
+  int tos_val = 0;
+  socklen_t tos_len = sizeof(tos_val);
+
+  if (getsockopt(sock_, IPPROTO_TCP, IP_TOS,  &tos_val, &tos_len) < 0) {
+    ROS_ERROR("getsockopt failed to get ip_tos");
+  } else {
+    ROS_ERROR("ip_tos set to %d on socket [%d] [%s]", tos_val, sock_, cached_remote_host_.c_str());
   }
 }
 

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -100,6 +100,7 @@ bool TransportPublisherLink::initialize(const ConnectionPtr& connection)
     header["callerid"] = this_node::getName();
     header["type"] = parent->datatype();
     header["tcp_nodelay"] = transport_hints_.getTCPNoDelay() ? "1" : "0";
+    header["ip_tos"] = boost::lexical_cast<std::string>(transport_hints_.getIpTos());
     connection_->writeHeader(header, boost::bind(&TransportPublisherLink::onHeaderWritten, this, _1));
   }
   else


### PR DESCRIPTION
Fixes #20 (or at least makes it work).

1. `IPPROTO_TCP` -> `IPPROTO_IP`
2. Set `header["ip_tos"] = ` which is how it gets sent across the network.