### PR TITLE
Added `~priority` param to topic_tools

### DIFF
--- a/tools/topic_tools/src/relay.cpp
+++ b/tools/topic_tools/src/relay.cpp
@@ -32,6 +32,7 @@
 
 
 #include <cstdio>
+#include <netinet/ip.h>
 #include "topic_tools/shape_shifter.h"
 #include "topic_tools/parse.h"
 
@@ -170,6 +171,11 @@ int main(int argc, char **argv)
   pnh.getParam("lazy", g_lazy);
   if (unreliable)
     g_th.unreliable().reliable(); // Prefers unreliable, but will accept reliable.
+
+  bool priority = false;
+  pnh.getParam("priority", priority);
+  if (priority)
+    g_th.ipTos(IPTOS_DSCP_EF);
 
   pnh.param<bool>("stealth", g_stealth, false);
   if (g_stealth)


### PR DESCRIPTION
Adds a `priority` flag which will set the DSCP tag to `IPTOS_DSCP_EF`. We should be careful not to overuse this as it has a strict limit on bandwidth and will negatively affect other traffic. If we find it useful, we might want to change from a bool to an int so we can set any flag but that can be a future update.