### PR TITLE
RST-2875 Adding real clock time display option

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -97,6 +97,8 @@ struct ROSBAG_DECL PlayerOptions
     std::string rate_control_topic;
     float    rate_control_max_delay;
     ros::Duration skip_empty;
+    bool     utc_time;
+    bool     local_time;
 
     std::vector<std::string> bags;
     std::vector<std::string> topics;
@@ -212,6 +214,8 @@ private:
     bool pause_change_requested_;
 
     bool requested_pause_state_;
+
+    const std::string clock_time_format_;
 
     ros::Subscriber rate_control_sub_;
     ros::Time last_rate_control_;

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -50,6 +50,8 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("pause", "start in paused mode")
       ("queue", po::value<int>()->default_value(100), "use an outgoing queue of size SIZE")
       ("clock", "publish the clock time")
+      ("utc-time", "displays the time in UTC")
+      ("local-time,", "displays the time in the user's local timezone")
       ("hz", po::value<float>()->default_value(100.0f), "use a frequency of HZ when publishing clock time")
       ("delay,d", po::value<float>()->default_value(0.2f), "sleep SEC seconds after every advertise call (to allow subscribers to connect)")
       ("rate,r", po::value<float>()->default_value(1.0f), "multiply the publish rate by FACTOR")
@@ -148,6 +150,15 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
 
     if (vm.count("rate-control-max-delay"))
       opts.rate_control_max_delay = vm["rate-control-max-delay"].as<float>();
+
+    if (vm.count("utc-time") && vm.count("local-time"))
+      throw ros::Exception("utc-time and local-time are mutually exclusive. Please use only one.");
+
+    if (vm.count("utc-time"))
+      opts.utc_time = true;
+
+    if (vm.count("local-time"))
+      opts.local_time = true;
 
     if (vm.count("bags"))
     {


### PR DESCRIPTION
Addresses https://locusrobotics.atlassian.net/browse/RST-2875

```
automatom@automatom-dt:~$ rosrun rosbag play /home/automatom/locus-p3_3170_2021-06-09-13-55-24_379.bag --utc-time
[ INFO] [/play_1623669959770349590]: Opening /home/automatom/locus-p3_3170_2021-06-09-13-55-24_379.bag

Waiting 0.2 seconds after advertising topics... done.

Hit space to toggle paused, or 's' to step.
 [PAUSED ]  Bag Time: 2021-06-09 13:55:25.217356 GMT  Duration: 0.640219 / 600.000786  
 ```