### PR TITLE
RST-2875 Passing time args through to the actual rosbag play executable

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -222,6 +222,8 @@ def play_cmd(argv):
     parser.add_option("--pause",              dest="pause",      default=False, action="store_true", help="start in paused mode")
     parser.add_option("--queue",              dest="queue",      default=100,     type='int', action="store", help="use an outgoing queue of size SIZE (defaults to %default)", metavar="SIZE")
     parser.add_option("--clock",              dest="clock",      default=False, action="store_true", help="publish the clock time")
+    parser.add_option("--utc-time",           dest="utc_time",   default=False, action="store_true", help="display the time in UTC")
+    parser.add_option("--local-time",         dest="local_time", default=False, action="store_true", help="display the time in the user's local timezone")
     parser.add_option("--hz",                 dest="freq",       default=100,   type='float', action="store", help="use a frequency of HZ when publishing clock time (default: %default)", metavar="HZ")
     parser.add_option("-d", "--delay",        dest="delay",      default=0.2,   type='float', action="store", help="sleep SEC seconds after every advertise call (to allow subscribers to connect)", metavar="SEC")
     parser.add_option("-r", "--rate",         dest="rate",       default=1.0,   type='float', action="store", help="multiply the publish rate by FACTOR", metavar="FACTOR")
@@ -261,6 +263,8 @@ def play_cmd(argv):
     if options.keep_alive: cmd.extend(["--keep-alive"])
     if options.try_future: cmd.extend(["--try-future-version"])
     if options.wait_for_subscribers: cmd.extend(["--wait-for-subscribers"])
+    if options.utc_time:   cmd.extend(["--utc-time"])
+    if options.local_time: cmd.extend(["--local-time"])
 
     if options.clock:
         cmd.extend(["--clock", "--hz", str(options.freq)])


### PR DESCRIPTION
I added the new time display features, but then you need to edit the `rosbag` script to pass them through to the `play` executable.