### PR TITLE
RST-3950: Add timeout to handshake

### DIFF
--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -78,19 +78,19 @@ def parse_http_host_and_port(url):
     port due to the fact that Python only provides easy accessors in
     Python 2.5 and later. Validation checks that the protocol and host
     are set.
-    
+
     :param url: URL to parse, ``str``
     :returns: hostname and port number in URL or 80 (default), ``(str, int)``
     :raises: :exc:`ValueError` If the url does not validate
     """
     if not url:
-        raise ValueError('not a valid URL')        
+        raise ValueError('not a valid URL')
     p = urlparse.urlparse(url)
     if not p.scheme or not p.hostname:
         raise ValueError('not a valid URL')
     port = p.port if p.port else 80
     return p.hostname, port
-    
+
 def _is_unix_like_platform():
     """
     :returns: true if the platform conforms to UNIX/POSIX-style APIs
@@ -172,7 +172,7 @@ def is_local_address(hostname):
     if ([ip for ip in reverse_ips if (ip.startswith('127.') or ip == '::1')] != []) or (set(reverse_ips) & set(local_addresses) != set()):
         return True
     return False
-    
+
 def get_local_address():
     """
     :returns: default local IP address (e.g. eth0). May be overridden by ROS_IP/ROS_HOSTNAME/__ip/__hostname, ``str``
@@ -285,7 +285,7 @@ def create_local_xmlrpc_uri(port):
     logic of checking ROS environment variables, the known hostname,
     and local interface IP addresses to determine the best possible
     URI.
-    
+
     :param port: port that server is running on, ``int``
     :returns: XMLRPC URI, ``str``
     """
@@ -309,7 +309,7 @@ def decode_ros_handshake_header(header_str):
     header is a list of string key=value pairs, each prefixed by a
     4-byte length field. It is preceded by a 4-byte length field for
     the entire header.
-    
+
     :param header_str: encoded header string. May contain extra data at the end, ``str``
     :returns: key value pairs encoded in \a header_str, ``{str: str}``
     """
@@ -329,11 +329,11 @@ def decode_ros_handshake_header(header_str):
         if start > size:
             raise ROSHandshakeException("Invalid line length in handshake header: %s"%size)
         line = header_str[start-field_size:start]
-        
+
         #python3 compatibility
         if python3 == 1:
             line = line.decode()
-        
+
         idx = line.find("=")
         if idx < 0:
             raise ROSHandshakeException("Invalid line in handshake header: [%s]"%line)
@@ -341,11 +341,11 @@ def decode_ros_handshake_header(header_str):
         value = line[idx+1:]
         d[key.strip()] = value
     return d
-    
+
 def read_ros_handshake_header(sock, b, buff_size):
     """
     Read in tcpros header off the socket \a sock using buffer \a b.
-    
+
     :param sock: socket must be in blocking mode, ``socket``
     :param b: buffer to use, ``StringIO`` for Python2, ``BytesIO`` for Python 3
     :param buff_size: incoming buffer size to use, ``int``
@@ -357,7 +357,7 @@ def read_ros_handshake_header(sock, b, buff_size):
         # Remember timeout so we can reset it later
         prev_timeout = sock.gettimeout()
         try:
-            sock.settimeout(1.0)
+            sock.settimeout(3.0)
             d = sock.recv(buff_size)
         except socket.timeout:
             raise ROSHandshakeException("connection from sender timed out before handshake header received. Please check sender %s:%d for additional details." % sock.getpeername())
@@ -375,14 +375,14 @@ def read_ros_handshake_header(sock, b, buff_size):
             (size,) = struct.unpack('<I', bval[0:4])
             if btell - 4 >= size:
                 header_str = bval
-                    
+
                 # memmove the remnants of the buffer back to the start
                 leftovers = bval[size+4:]
                 b.truncate(len(leftovers))
                 b.seek(0)
                 b.write(leftovers)
                 header_recvd = True
-                    
+
     # process the header
     return decode_ros_handshake_header(bval)
 
@@ -399,7 +399,7 @@ def encode_ros_handshake_header(header):
     :returns: header encoded as byte string, ``bytes``
     """
     str_cls = str if python3 else unicode
-    
+
     # encode all unicode keys in the header. Ideally, the type of these would be specified by the api
     encoded_header = {}
     for k, v in header.items():
@@ -411,9 +411,9 @@ def encode_ros_handshake_header(header):
 
     fields = [k + b"=" + v for k, v in sorted(encoded_header.items())]
     s = b''.join([struct.pack('<I', len(f)) + f for f in fields])
-    
+
     return struct.pack('<I', len(s)) + s
-                                        
+
 def write_ros_handshake_header(sock, header):
     """
     Write ROS handshake header header to socket sock
@@ -425,4 +425,3 @@ def write_ros_handshake_header(sock, header):
     s = encode_ros_handshake_header(header)
     sock.sendall(s)
     return len(s) #STATS
-    

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -78,19 +78,19 @@ def parse_http_host_and_port(url):
     port due to the fact that Python only provides easy accessors in
     Python 2.5 and later. Validation checks that the protocol and host
     are set.
-
+    
     :param url: URL to parse, ``str``
     :returns: hostname and port number in URL or 80 (default), ``(str, int)``
     :raises: :exc:`ValueError` If the url does not validate
     """
     if not url:
-        raise ValueError('not a valid URL')
+        raise ValueError('not a valid URL')        
     p = urlparse.urlparse(url)
     if not p.scheme or not p.hostname:
         raise ValueError('not a valid URL')
     port = p.port if p.port else 80
     return p.hostname, port
-
+    
 def _is_unix_like_platform():
     """
     :returns: true if the platform conforms to UNIX/POSIX-style APIs
@@ -172,7 +172,7 @@ def is_local_address(hostname):
     if ([ip for ip in reverse_ips if (ip.startswith('127.') or ip == '::1')] != []) or (set(reverse_ips) & set(local_addresses) != set()):
         return True
     return False
-
+    
 def get_local_address():
     """
     :returns: default local IP address (e.g. eth0). May be overridden by ROS_IP/ROS_HOSTNAME/__ip/__hostname, ``str``
@@ -285,7 +285,7 @@ def create_local_xmlrpc_uri(port):
     logic of checking ROS environment variables, the known hostname,
     and local interface IP addresses to determine the best possible
     URI.
-
+    
     :param port: port that server is running on, ``int``
     :returns: XMLRPC URI, ``str``
     """
@@ -309,7 +309,7 @@ def decode_ros_handshake_header(header_str):
     header is a list of string key=value pairs, each prefixed by a
     4-byte length field. It is preceded by a 4-byte length field for
     the entire header.
-
+    
     :param header_str: encoded header string. May contain extra data at the end, ``str``
     :returns: key value pairs encoded in \a header_str, ``{str: str}``
     """
@@ -329,11 +329,11 @@ def decode_ros_handshake_header(header_str):
         if start > size:
             raise ROSHandshakeException("Invalid line length in handshake header: %s"%size)
         line = header_str[start-field_size:start]
-
+        
         #python3 compatibility
         if python3 == 1:
             line = line.decode()
-
+        
         idx = line.find("=")
         if idx < 0:
             raise ROSHandshakeException("Invalid line in handshake header: [%s]"%line)
@@ -341,11 +341,11 @@ def decode_ros_handshake_header(header_str):
         value = line[idx+1:]
         d[key.strip()] = value
     return d
-
+    
 def read_ros_handshake_header(sock, b, buff_size):
     """
     Read in tcpros header off the socket \a sock using buffer \a b.
-
+    
     :param sock: socket must be in blocking mode, ``socket``
     :param b: buffer to use, ``StringIO`` for Python2, ``BytesIO`` for Python 3
     :param buff_size: incoming buffer size to use, ``int``
@@ -357,7 +357,7 @@ def read_ros_handshake_header(sock, b, buff_size):
         # Remember timeout so we can reset it later
         prev_timeout = sock.gettimeout()
         try:
-            sock.settimeout(3.0)
+            sock.settimeout(1.0)
             d = sock.recv(buff_size)
         except socket.timeout:
             raise ROSHandshakeException("connection from sender timed out before handshake header received. Please check sender %s:%d for additional details." % sock.getpeername())
@@ -375,14 +375,14 @@ def read_ros_handshake_header(sock, b, buff_size):
             (size,) = struct.unpack('<I', bval[0:4])
             if btell - 4 >= size:
                 header_str = bval
-
+                    
                 # memmove the remnants of the buffer back to the start
                 leftovers = bval[size+4:]
                 b.truncate(len(leftovers))
                 b.seek(0)
                 b.write(leftovers)
                 header_recvd = True
-
+                    
     # process the header
     return decode_ros_handshake_header(bval)
 
@@ -399,7 +399,7 @@ def encode_ros_handshake_header(header):
     :returns: header encoded as byte string, ``bytes``
     """
     str_cls = str if python3 else unicode
-
+    
     # encode all unicode keys in the header. Ideally, the type of these would be specified by the api
     encoded_header = {}
     for k, v in header.items():
@@ -411,9 +411,9 @@ def encode_ros_handshake_header(header):
 
     fields = [k + b"=" + v for k, v in sorted(encoded_header.items())]
     s = b''.join([struct.pack('<I', len(f)) + f for f in fields])
-
+    
     return struct.pack('<I', len(s)) + s
-
+                                        
 def write_ros_handshake_header(sock, header):
     """
     Write ROS handshake header header to socket sock
@@ -425,3 +425,4 @@ def write_ros_handshake_header(sock, header):
     s = encode_ros_handshake_header(header)
     sock.sendall(s)
     return len(s) #STATS
+    

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -366,7 +366,6 @@ def read_ros_handshake_header(sock, b, buff_size):
 
         if not d:
             raise ROSHandshakeException("connection from sender terminated before handshake header received. %s bytes were received. Please check sender for additional details."%b.tell())
-
         b.write(d)
         btell = b.tell()
         if btell > 4:

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -357,7 +357,7 @@ def read_ros_handshake_header(sock, b, buff_size):
         # Remember timeout so we can reset it later
         prev_timeout = sock.gettimeout()
         try:
-            sock.settimeout(1.0)
+            sock.settimeout(3.0)
             d = sock.recv(buff_size)
         except socket.timeout:
             raise ROSHandshakeException("connection from sender timed out before handshake header received. Please check sender %s:%d for additional details." % sock.getpeername())

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -354,9 +354,19 @@ def read_ros_handshake_header(sock, b, buff_size):
     """
     header_str = None
     while not header_str:
-        d = sock.recv(buff_size)
+        # Remember timeout so we can reset it later
+        prev_timeout = sock.gettimeout()
+        try:
+            sock.settimeout(1.0)
+            d = sock.recv(buff_size)
+        except socket.timeout:
+            raise ROSHandshakeException("connection from sender timed out before handshake header received. Please check sender %s:%d for additional details." % sock.getpeername())
+        finally:
+            sock.settimeout(prev_timeout)
+
         if not d:
             raise ROSHandshakeException("connection from sender terminated before handshake header received. %s bytes were received. Please check sender for additional details."%b.tell())
+
         b.write(d)
         btell = b.tell()
         if btell > 4:


### PR DESCRIPTION
Set a socket timeout when waiting to `recv()` the handshake header. For some reason this is done in the main "accept" thread so this will block everything if there isn't a timeout. I don't know why the handshake isn't being sent or received.

Setting a timeout of 1 second seems to work well in the sim but even then with 200 robots restarting I had about 25 of them hitting the timeout. So even with a relatively short timeout the accept thread is still blocked for 25 seconds...

---

I tracked this down using the stack traces of a working instances threads and one that was locked up. Most of the traces were identical apart from this one:

working:
```
Thread 3454 (idle): "Thread-4"
    accept (socket.py:205)
    run (rospy/impl/tcpros_base.py:154)
    run (threading.py:864)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
```

locked:
```
Thread 11282 (idle): "Thread-4"
    read_ros_handshake_header (rosgraph/network.py:357)
    _tcp_server_callback (rospy/impl/tcpros_base.py:325)
    run (rospy/impl/tcpros_base.py:167)
    run (threading.py:864)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
```