### PR TITLE
If a default param value is passed in, store in cache

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -487,7 +487,12 @@ def get_param_cached(param_name, default=_unspecified):
     """
     try:
         _init_param_server()
-        return _param_server.get_param_cached(param_name)
+        if default == _unspecified:
+            # No default supplied
+            return _param_server.get_param_cached(param_name)
+        else:
+            return _param_server.get_param_cached(param_name, default)
+
     except KeyError:
         if default != _unspecified:
             return default

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -158,7 +158,7 @@ class MasterProxy(object):
         else:
             raise rospy.exceptions.ROSException("cannot search for parameter: %s"%msg)
 
-    def get_param_cached(self, key):
+    def get_param_cached(self, key, default={}):
         resolved_key = rospy.names.resolve_name(key)
         try:
             # check for value in the parameter server cache
@@ -168,10 +168,17 @@ class MasterProxy(object):
             code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
             if code != 1: #unwrap value with Python semantics
                 raise KeyError(key)
+
+            if isinstance(value, dict) and not value:
+                # Param is not set on the server.
+                # Set the default value in the cache so that it's marked as subscribed and we don't
+                # spam the master. Keep the default local to the cache to avoid race conditions if
+                # nodes have different defaults.
+                rospy.impl.paramserver.get_param_server_cache().set(resolved_key, default)
+                raise KeyError(key)
+
             # set the value in the cache so that it's marked as subscribed
             rospy.impl.paramserver.get_param_server_cache().set(resolved_key, value)
-            if isinstance(value, dict) and not value:
-                raise KeyError(key)
             return value
         
     def __delitem__(self, key):


### PR DESCRIPTION
When using the `get_cached_param` method, there is an assumption that 
1. the param is set
2. or the default will be used

If the param is not set, the default is returned however it isn't stored in the cache. Instead an empty dict is stored which can later be updated if the param is set. The problem with this is that the ros master is queried every time rather than just once at the start to register the param. For high-frequency params like `/rosout_disable_topics_generation` this can cause a large performance hit.

This PR changes the internal behavior slightly so that if a default param value is passed in, it is stored in the local cache instead of an empty dict. This way the next call will hit the cache and avoid a call to the master. It _doesn't_ store the value on the param server as different nodes may have different defaults and we don't want to cause a race.