### PR TITLE
Added playback finished status

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT WIN32)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
-find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
+find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_msgs std_srvs topic_tools xmlrpcpp)
 find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options regex thread)
 find_package(BZip2 REQUIRED)
 

--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -206,6 +206,8 @@ private:
 
     ros::ServiceServer pause_service_;
 
+    ros::Publisher playback_finished_publisher_;
+
     bool paused_;
     bool delayed_;
 

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -31,6 +31,7 @@
   <depend>rosbag_storage</depend>
   <depend>rosconsole</depend>
   <depend>roscpp</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>xmlrpcpp</depend>
 

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -42,6 +42,7 @@
 
 #include <boost/format.hpp>
 
+#include "std_msgs/Bool.h"
 #include "rosgraph_msgs/Clock.h"
 
 #include <ctime>
@@ -123,6 +124,7 @@ Player::Player(PlayerOptions const& options) :
 {
   ros::NodeHandle private_node_handle("~");
   pause_service_ = private_node_handle.advertiseService("pause_playback", &Player::pauseCallback, this);
+  playback_finished_publisher_ = private_node_handle.advertise<std_msgs::Bool>("playback_finished", 1, true);
 }
 
 Player::~Player() {
@@ -292,6 +294,9 @@ void Player::publish() {
     while (true) {
         // Set up our time_translator and publishers
 
+        std_msgs::Bool replay_finished;
+        replay_finished.data = false;
+
         time_translator_.setTimeScale(options_.time_scale);
 
         start_time_ = view.begin()->getTime();
@@ -315,6 +320,7 @@ void Player::publish() {
 
         paused_time_ = now_wt;
 
+        playback_finished_publisher_.publish(replay_finished);
         // Call do-publish for each message
         for (const MessageInstance& m : view) {
             if (!node_handle_.ok())
@@ -322,7 +328,8 @@ void Player::publish() {
 
             doPublish(m);
         }
-
+        replay_finished.data = true;
+        playback_finished_publisher_.publish(replay_finished);
         if (options_.keep_alive)
             while (node_handle_.ok())
                 doKeepAlive();


### PR DESCRIPTION
The goal of this small change is to let other nodes know that the rosbag is over, even if the `keep_alive` option is set. Right now this is only applicable to mapping, where the goal is to save the last state (as @DavidLocus is doing for cloud mapping) without having to create some workarounds. Once we receive `true` on the `playback_finished` topic (note that this would need to be remapped as we do with the service due to the anonymous mode), we can do that. 