### PR TITLE
Remove raise

### DIFF
--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -212,7 +212,6 @@ def publisher_update_task(api, topic, pub_uris):
         msg_suffix = "result=%s" % ret
     except Exception as ex:
         msg_suffix = "exception=%s" % ex
-        mloginfo(msg_suffix)
     finally:
         delta_sec = time.time() - start_sec
         mloginfo("%s: sec=%0.2f, %s", msg, delta_sec, msg_suffix)

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -61,7 +61,6 @@ import logging
 import threading
 import time
 import traceback
-import xmlrpc.client
 
 from rosgraph.xmlrpc import XmlRpcHandler
 

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -61,6 +61,7 @@ import logging
 import threading
 import time
 import traceback
+import xmlrpc.client
 
 from rosgraph.xmlrpc import XmlRpcHandler
 
@@ -211,7 +212,7 @@ def publisher_update_task(api, topic, pub_uris):
         msg_suffix = "result=%s" % ret
     except Exception as ex:
         msg_suffix = "exception=%s" % ex
-        raise
+        mloginfo(msg_suffix)
     finally:
         delta_sec = time.time() - start_sec
         mloginfo("%s: sec=%0.2f, %s", msg, delta_sec, msg_suffix)


### PR DESCRIPTION
When shutting down python nodes the logs get clogged with

[rosmaster.threadpool][ERROR] 2015-02-20 10:16:02,810: Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rosmaster/threadpool.py", line 218, in run
    result = cmd(*args)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rosmaster/master_api.py", line 208, in publisher_update_task
    xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
    
   and other trackbacks.
   
   The raise has been removed and only the error is output to the logs. 