### PR TITLE
RST-10804: Remove reconnect for read errors

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -798,22 +798,11 @@ class TCPROSTransport(Transport):
                         msgs = self.receive_once()
                         if not self.done and not is_shutdown():
                             msgs_callback(msgs, self)
-                    else:
-                        self._reconnect()
 
                 except TransportException as e:
-                    # set socket to None so we reconnect
-                    try:
-                        if self.socket is not None:
-                            try:
-                                self.socket.shutdown()
-                            except:
-                                pass
-                            finally:
-                                self.socket.close()
-                    except:
-                        pass
-                    self.socket = None
+                    # A transport exception means the connection has been closed from the other side.
+                    # Clean up our side.
+                    self.close()
 
                 except DeserializationError as e:
                     #TODO: how should we handle reconnect in this case?


### PR DESCRIPTION
When rospy is running a subscriber and the connection is broken because the publisher was removed, the code would try to reconnect to the same socket again. This aren't many cases this would work. Instead, we can just close the connection properly.

The actual issue we were hitting is the connection would be blocked for a certain time after all publishers had been removed. This was caused by the reconnect function having an [exponential backoff up to 32 seconds](https://github.com/ros/ros_comm/blob/845f74602c7464e08ef5ac6fd9e26c97d0fe42c9/clients/rospy/src/rospy/impl/tcpros_base.py#L787). So after a couple of attempts, we would be required to wait up to 32 seconds after a new connection before we start sending data.

I'm fairly confident this is safe for a few reasons. The first is that this is what happens on a [write error](https://github.com/ros/ros_comm/blob/845f74602c7464e08ef5ac6fd9e26c97d0fe42c9/clients/rospy/src/rospy/impl/tcpros_base.py#L704), there isn't any reason that _read_ should behave differently. Secondly, the code on the publisher side will send updates to the master when a socket is created and so the master will trigger the broken subscriber to restart through that path. Finally, it seems to be what the [C++ code](https://github.com/ros/ros_comm/blob/845f74602c7464e08ef5ac6fd9e26c97d0fe42c9/clients/roscpp/src/libros/transport/transport_tcp.cpp#L523) does (although it does check for specific errors and ignores them, but we don't have access to those errors in this part of the python codebase).



Before:
```
➜ python pub2_unregister_bug.py
[DEBUG] [/pub_bug] [1723545135.109052]: init_node, name[/pub_bug], pid[101918]
[DEBUG] [/pub_bug] [1723545135.110868]: binding to 0.0.0.0 0
[DEBUG] [/pub_bug] [1723545135.111083]: bound to 0.0.0.0 42657
[DEBUG] [/pub_bug] [1723545135.111691]: ... service URL is rosrpc://LOCLAP858:42657
[DEBUG] [/pub_bug] [1723545135.111914]: [/pub_bug/get_loggers]: new Service instance
[DEBUG] [/pub_bug] [1723545135.113586]: ... service URL is rosrpc://LOCLAP858:42657
[DEBUG] [/pub_bug] [1723545135.113791]: [/pub_bug/set_logger_level]: new Service instance
Publish!
[DEBUG] [/pub_bug] [1723545135.129301]: connecting to LOCLAP858 42657
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Unregister Pub ...
[DEBUG] [/pub_bug] [1723545139.128715]: connecting to LOCLAP858 42657
[WARN] [/pub_bug] [1723545139.131163]: Could not process inbound connection: [/pub_bug] is not a publisher of [/topic]. Topics are [['/rosout', 'rosgraph_msgs/Log']]{'callerid': '/pub_bug', 'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', 'message_definition': 'string data\n', 'tcp_nodelay': '0', 'topic': '/topic', 'type': 'std_msgs/String'}
No publish!
No publish!
No publish![DEBUG] [/pub_bug] [1723545140.134608]: connecting to LOCLAP858 42657

[WARN] [/pub_bug] [1723545140.136757]: Could not process inbound connection: [/pub_bug] is not a publisher of [/topic]. Topics are [['/rosout', 'rosgraph_msgs/Log']]{'callerid': '/pub_bug', 'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', 'message_definition': 'string data\n', 'tcp_nodelay': '0', 'topic': '/topic', 'type': 'std_msgs/String'}
No publish!
No publish!
No publish!
No publish!
[DEBUG] [/pub_bug] [1723545142.139518]: connecting to LOCLAP858 42657
[WARN] [/pub_bug] [1723545142.141509]: Could not process inbound connection: [/pub_bug] is not a publisher of [/topic]. Topics are [['/rosout', 'rosgraph_msgs/Log']]{'callerid': '/pub_bug', 'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', 'message_definition': 'string data\n', 'tcp_nodelay': '0', 'topic': '/topic', 'type': 'std_msgs/String'}
No publish!
Re-create pub
Publish!
Publish!
Publish!
Publish!
Publish!
Publish!
Publish!
[DEBUG] [/pub_bug] [1723545146.147611]: connecting to LOCLAP858 42657
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
```

After:
```
➜ python pub2_unregister_bug.py
[DEBUG] [/pub_bug] [1723543779.234174]: init_node, name[/pub_bug], pid[88080]
[DEBUG] [/pub_bug] [1723543779.235226]: binding to 0.0.0.0 0
[DEBUG] [/pub_bug] [1723543779.235310]: bound to 0.0.0.0 42141
[DEBUG] [/pub_bug] [1723543779.235563]: ... service URL is rosrpc://LOCLAP858:42141
[DEBUG] [/pub_bug] [1723543779.235651]: [/pub_bug/get_loggers]: new Service instance
[DEBUG] [/pub_bug] [1723543779.236195]: ... service URL is rosrpc://LOCLAP858:42141
[DEBUG] [/pub_bug] [1723543779.236260]: [/pub_bug/set_logger_level]: new Service instance
Publish!
[DEBUG] [/pub_bug] [1723543779.239959]: connecting to LOCLAP858 42141
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Unregister Pub ...
No publish!
No publish!
No publish!
No publish!
No publish!
No publish!
No publish!
No publish!
Re-create pub
Publish!
[DEBUG] [/pub_bug] [1723543787.294682]: connecting to LOCLAP858 42141
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
Publish!
Received: data: "hello from pub2"
```
[test_scripts.zip](https://github.com/user-attachments/files/16597997/test_scripts.zip)

