### PR TITLE
RST-11203 Copy latched messages once per split with connection header

### DIFF
--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -462,18 +462,6 @@ void Recorder::startWriting() {
         {
             // Overwrite the original receipt time, otherwise the new bag will
             // have a gap before the new messages start.
-            bag_.write(out.second.topic, now, *out.second.msg);
-        }
-    }
-
-    if (options_.repeat_latched)
-    {
-        // Start each new bag file with copies of all latched messages.
-        ros::Time now = ros::Time::now();
-        for (auto const& out : latched_msgs_)
-        {
-            // Overwrite the original receipt time, otherwise the new bag will
-            // have a gap before the new messages start.
             bag_.write(out.second.topic, now, *out.second.msg, out.second.connection_header);
         }
     }


### PR DESCRIPTION
Eliminates a nearly identical copy of latched messages that was missing the original connection header, causing them to publish as unlatched.