### PR TITLE
Fixing string deprecation warning in noble

### DIFF
--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -160,8 +160,8 @@ class TestRospyCore(unittest.TestCase):
 
                     log_file = ' '.join([
                         '\[rosout\]\[' + lvl2loglvl(lvl) + '\]',
-                        '(\d+[-\/]\d+[-\/]\d+)',
-                        '(\d+[:]\d+[:]\d+[,]\d+):',
+                        r'(\d+[-\/]\d+[-\/]\d+)',
+                        r'(\d+[:]\d+[:]\d+[,]\d+):',
                         lvl
                     ])
                     fileline = lf.readline()

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1565,7 +1565,7 @@ class Bag(object):
         if len(version_line) == 0:
             raise ROSBagException('empty file')
         
-        matches = re.match("#ROS(.*) V(\d).(\d)", version_line)
+        matches = re.match(r"#ROS(.*) V(\d).(\d)", version_line)
         if matches is None or len(matches.groups()) != 3:
             raise ROSBagException('This does not appear to be a bag file')
         


### PR DESCRIPTION
Fixes this when playing bags:

```
/opt/locusrobotics/ubuntu24/dev/ros1/lib/python3/dist-packages/rosbag/bag.py:1568: SyntaxWarning: invalid escape sequence '\d'
  matches = re.match("#ROS(.*) V(\d).(\d)", version_line)
```