### PR TITLE
Make get/free ifaddrs thread safe

### DIFF
--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -39,6 +39,7 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <mutex>
 #include <vector>
 
 namespace ros
@@ -149,6 +150,7 @@ protected:
 private:
   bool only_localhost_allowed_;
   std::vector<std::string> allowed_hosts_;
+  std::mutex ifaddrs_mutex_;
 };
 
 }

--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -150,7 +150,7 @@ protected:
 private:
   bool only_localhost_allowed_;
   std::vector<std::string> allowed_hosts_;
-  std::mutex ifaddrs_mutex_;
+  std::recursive_mutex ifaddrs_mutex_;
 };
 
 }

--- a/clients/roscpp/include/ros/transport/transport_tcp.h
+++ b/clients/roscpp/include/ros/transport/transport_tcp.h
@@ -165,6 +165,7 @@ private:
 
   std::string connected_host_;
   int connected_port_;
+  std::recursive_mutex addrinfo_mutex_;
 };
 
 }

--- a/clients/roscpp/include/ros/transport/transport_udp.h
+++ b/clients/roscpp/include/ros/transport/transport_udp.h
@@ -42,6 +42,8 @@
 #include "ros/io.h"
 #include <ros/common.h>
 
+#include <mutex>
+
 namespace ros
 {
 
@@ -169,6 +171,7 @@ private:
   uint8_t* reorder_start_;
   TransportUDPHeader reorder_header_;
   uint32_t reorder_bytes_;
+  std::recursive_mutex addrinfo_mutex_;
 };
 
 }

--- a/clients/roscpp/src/libros/network.cpp
+++ b/clients/roscpp/src/libros/network.cpp
@@ -35,6 +35,7 @@
 #ifdef HAVE_IFADDRS_H
   #include <ifaddrs.h>
   #include <sys/socket.h>  // supports FreeBSD, which does not include this in ifaddrs.h
+  #include <mutex>
 #endif
 
 #include <boost/lexical_cast.hpp>
@@ -47,6 +48,9 @@ namespace network
 
 std::string g_host;
 uint16_t g_tcpros_server_port = 0;
+#ifdef HAVE_IFADDRS_H
+std::mutex g_ifaddrs_mutex;
+#endif
 
 const std::string& getHost()
 {
@@ -124,6 +128,7 @@ std::string determineHost()
   // Fourth, fall back on interface search, which will yield an IP address
 
 #ifdef HAVE_IFADDRS_H
+  std::lock_guard<std::mutex> lock(g_ifaddrs_mutex);
   struct ifaddrs *ifa = NULL, *ifp = NULL;
   int rc;
   if ((rc = getifaddrs(&ifp)) < 0)

--- a/clients/roscpp/src/libros/network.cpp
+++ b/clients/roscpp/src/libros/network.cpp
@@ -35,7 +35,6 @@
 #ifdef HAVE_IFADDRS_H
   #include <ifaddrs.h>
   #include <sys/socket.h>  // supports FreeBSD, which does not include this in ifaddrs.h
-  #include <mutex>
 #endif
 
 #include <boost/lexical_cast.hpp>
@@ -48,9 +47,6 @@ namespace network
 
 std::string g_host;
 uint16_t g_tcpros_server_port = 0;
-#ifdef HAVE_IFADDRS_H
-std::recursive_mutex g_ifaddrs_mutex;
-#endif
 
 const std::string& getHost()
 {
@@ -128,7 +124,6 @@ std::string determineHost()
   // Fourth, fall back on interface search, which will yield an IP address
 
 #ifdef HAVE_IFADDRS_H
-  std::lock_guard<std::recursive_mutex> lock(g_ifaddrs_mutex);
   struct ifaddrs *ifa = NULL, *ifp = NULL;
   int rc;
   if ((rc = getifaddrs(&ifp)) < 0)

--- a/clients/roscpp/src/libros/network.cpp
+++ b/clients/roscpp/src/libros/network.cpp
@@ -49,7 +49,7 @@ namespace network
 std::string g_host;
 uint16_t g_tcpros_server_port = 0;
 #ifdef HAVE_IFADDRS_H
-std::mutex g_ifaddrs_mutex;
+std::recursive_mutex g_ifaddrs_mutex;
 #endif
 
 const std::string& getHost()
@@ -128,7 +128,7 @@ std::string determineHost()
   // Fourth, fall back on interface search, which will yield an IP address
 
 #ifdef HAVE_IFADDRS_H
-  std::lock_guard<std::mutex> lock(g_ifaddrs_mutex);
+  std::lock_guard<std::recursive_mutex> lock(g_ifaddrs_mutex);
   struct ifaddrs *ifa = NULL, *ifp = NULL;
   int rc;
   if ((rc = getifaddrs(&ifp)) < 0)

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -33,7 +33,7 @@
 
 #include <ros/console.h>
 
-#include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <vector>
@@ -47,7 +47,7 @@ namespace param
 
 typedef std::map<std::string, XmlRpc::XmlRpcValue> M_Param;
 M_Param g_params;
-boost::mutex g_params_mutex;
+boost::recursive_mutex g_params_mutex;
 S_string g_subscribed_params;
 
 void invalidateParentParams(const std::string& key)
@@ -76,7 +76,7 @@ void set(const std::string& key, const XmlRpc::XmlRpcValue& v)
   {
     // Lock around the execute to the master in case we get a parameter update on this value between
     // executing on the master and setting the parameter in the g_params list.
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
     if (master::execute("setParam", params, result, payload, true))
     {
@@ -230,7 +230,7 @@ bool del(const std::string& key)
   std::string mapped_key = ros::names::resolve(key);
 
   {
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
     if (g_subscribed_params.find(mapped_key) != g_subscribed_params.end())
     {
@@ -261,7 +261,7 @@ bool getImpl(const std::string& key, XmlRpc::XmlRpcValue& v, bool use_cache)
 
   if (use_cache)
   {
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
     if (g_subscribed_params.find(mapped_key) != g_subscribed_params.end())
     {
@@ -309,7 +309,7 @@ bool getImpl(const std::string& key, XmlRpc::XmlRpcValue& v, bool use_cache)
 
   if (use_cache)
   {
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
     g_params[mapped_key] = v;
   }
 
@@ -783,7 +783,7 @@ void update(const std::string& key, const XmlRpc::XmlRpcValue& v)
   std::string clean_key = names::clean(key);
   ROS_DEBUG_NAMED("cached_parameters", "Received parameter update for key [%s]", clean_key.c_str());
 
-  boost::mutex::scoped_lock lock(g_params_mutex);
+  boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
   if (g_subscribed_params.find(clean_key) != g_subscribed_params.end())
   {
@@ -813,7 +813,7 @@ void unsubscribeCachedParam(const std::string& key)
 void unsubscribeCachedParam(void)
 {
   // lock required, all of the cached parameter will be unsubscribed.
-  boost::mutex::scoped_lock lock(g_params_mutex);
+  boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
   for(S_string::iterator itr = g_subscribed_params.begin();
     itr != g_subscribed_params.end(); ++itr)

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -44,6 +44,7 @@
 
 #if !defined(__ANDROID__) && !defined(WIN32)
 #include <ifaddrs.h>
+#include <mutex>
 #endif
 
 #ifndef NI_MAXHOST
@@ -79,6 +80,7 @@ Transport::Transport()
   // for ipv4 loopback, we'll explicitly search for 127.* in isHostAllowed()
   // now we need to iterate all local interfaces and add their addresses
   // from the getifaddrs manpage:  (maybe something similar for windows ?) 
+  std::lock_guard<std::mutex> lock(ifaddrs_mutex_);
   ifaddrs *ifaddr;
   if (-1 == getifaddrs(&ifaddr))
   {

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -80,7 +80,7 @@ Transport::Transport()
   // for ipv4 loopback, we'll explicitly search for 127.* in isHostAllowed()
   // now we need to iterate all local interfaces and add their addresses
   // from the getifaddrs manpage:  (maybe something similar for windows ?) 
-  std::lock_guard<std::mutex> lock(ifaddrs_mutex_);
+  std::lock_guard<std::recursive_mutex> lock(ifaddrs_mutex_);
   ifaddrs *ifaddr;
   if (-1 == getifaddrs(&ifaddr))
   {

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -287,6 +287,7 @@ bool TransportTCP::connect(const std::string& host, int port)
   }
   else
   {
+    std::lock_guard<std::recursive_mutex> lock(addrinfo_mutex_);
     struct addrinfo* addr;
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -166,6 +166,7 @@ bool TransportUDP::connect(const std::string& host, int port, int connection_id)
   sin.sin_family = AF_INET;
   if (inet_addr(host.c_str()) == INADDR_NONE)
   {
+    std::lock_guard<std::recursive_mutex> lock(addrinfo_mutex_);
     struct addrinfo* addr;
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));


### PR DESCRIPTION
getifaddrs had a memory leak which got fixed https://github.com/ros/ros_comm/commit/8f8f02e6fb39b47e2adbddc817fd80ae9e2946f0, but if for example, through ros::service::exists, gets called from multiple threads, then there is a potential for a realloc or malloc crash.