### PR TITLE
Disable topics aggregation by default

### DIFF
--- a/tools/roslaunch/resources/roscore.xml
+++ b/tools/roslaunch/resources/roscore.xml
@@ -6,6 +6,7 @@
   -->
 <launch>
   <group ns="/">
+    <param name="rosout_disable_topics_generation" type="bool" value="true"/>
     <param name="rosversion" command="rosversion roslaunch" />
     <param name="rosdistro" command="rosversion -d" />
     <node pkg="rosout" type="rosout" name="rosout" respawn="true"/>


### PR DESCRIPTION
To help with nav crash potentially due to increased number of advertised topics during cart 