### PR TITLE
Remove error due to SIGINT when running param_update_task

### DIFF
--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -576,7 +576,10 @@ class ROSMasterHandler(object):
         @type  param_value: str
         """
         mloginfo("paramUpdate[%s]", param_key)
-        code, _, _ = xmlrpcapi(caller_api).paramUpdate('/master', param_key, param_value)
+        try:
+            code, _, _ = xmlrpcapi(caller_api).paramUpdate('/master', param_key, param_value)
+        except ConnectionRefusedError as ex:
+            return
         if code == -1:
             try:
                 # ps_lock is required due to potential self.reg_manager modification


### PR DESCRIPTION
Remove error spam due to SIGINT exiting local sim

```
wrangler [INFO] [/resource_manager] [1752017412.912815]: [resource_manager.robot_comms.queue_handler] Robot 'sim_001' DEPARTED from QUEUE 910:2
wrangler [INFO] [/resource_manager] [1752017412.912900]: [resource_manager.robot_comms.queue_handler] Robot 'sim_001' DEPARTED from QUEUE 2:0
^C2025-07-08T23:30:13.900546Z  INFO nessy::command: Received SIGINT
2025-07-08T23:30:13.900599Z  INFO nessy::command: Killing process Pid(326351) with SIGINT
2025-07-08T23:30:13.900601Z  INFO nessy::command: Killing process Pid(326352) with SIGINT
2025-07-08T23:30:13.900605Z  INFO nessy::command: Killing process Pid(326354) with SIGINT
2025-07-08T23:30:13.900619Z  INFO nessy::command: Killing process Pid(326358) with SIGINT
2025-07-08T23:30:13.900606Z  INFO nessy::command: Killing process Pid(326356) with SIGINT
2025-07-08T23:30:13.900694Z  INFO nessy::command: Killing process Pid(326360) with SIGINT
ln-rst   [2025-07-08T23:30:13Z WARN  rocket::server] Received SIGINT. Requesting shutdown.
ln-rst   [2025-07-08T23:30:13Z INFO  rocket::server] Shutdown requested. Waiting for pending I/O...
ln-rst   [2025-07-08T23:30:13Z INFO  rocket::server] Graceful shutdown completed successfully.
sim_001  Exception in thread Send:
sim_001  Traceback (most recent call last):
sim_001    File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
sim_001      self.run()
sim_001    File "/usr/lib/python3.10/threading.py", line 953, in run
sim_001      self._target(*self._args, **self._kwargs)
sim_001    File "/opt/locusrobotics/hotdog/dev/ros1/lib/python3/dist-packages/sim_client/tcp_proto.py", line 55, in receive
sim_001      self.fill_buffer(buf)
sim_001    File "/opt/locusrobotics/hotdog/dev/ros1/lib/python3/dist-packages/sim_client/tcp_proto.py", line 65, in fill_buffer
sim_001      data = self.sock.recv(READ_BUFFER_LEN)
sim_001  ConnectionResetError: [Errno 104] Connection reset by peer
wrangler [ERROR] [rosmaster]: Traceback (most recent call last):
wrangler   File "/opt/locusrobotics/hotdog/dev/ros1/lib/python3/dist-packages/rosmaster/threadpool.py", line 218, in run
wrangler     result = cmd(*args)
wrangler   File "/opt/locusrobotics/hotdog/dev/ros1/lib/python3/dist-packages/rosmaster/master_api.py", line 579, in param_update_task
wrangler     code, _, _ = xmlrpcapi(caller_api).paramUpdate('/master', param_key, param_value)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1122, in __call__
wrangler     return self.__send(self.__name, args)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1464, in __request
wrangler     response = self.__transport.request(
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1166, in request
wrangler     return self.single_request(host, handler, request_body, verbose)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1178, in single_request
wrangler     http_conn = self.send_request(host, handler, request_body, verbose)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1291, in send_request
wrangler     self.send_content(connection, request_body)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1321, in send_content
wrangler     connection.endheaders(request_body)
wrangler   File "/usr/lib/python3.10/http/client.py", line 1278, in endheaders
wrangler     self._send_output(message_body, encode_chunked=encode_chunked)
wrangler   File "/usr/lib/python3.10/http/client.py", line 1038, in _send_output
wrangler     self.send(msg)
wrangler   File "/usr/lib/python3.10/http/client.py", line 976, in send
wrangler     self.connect()
wrangler   File "/usr/lib/python3.10/http/client.py", line 942, in connect
wrangler     self.sock = self._create_connection(
wrangler   File "/usr/lib/python3.10/socket.py", line 845, in create_connection
wrangler     raise err
wrangler   File "/usr/lib/python3.10/socket.py", line 833, in create_connection
wrangler     sock.connect(sa)
wrangler ConnectionRefusedError: [Errno 111] Connection refused
wrangler 
wrangler [ERROR] [rosmaster]: Traceback (most recent call last):
wrangler   File "/opt/locusrobotics/hotdog/dev/ros1/lib/python3/dist-packages/rosmaster/threadpool.py", line 218, in run
wrangler     result = cmd(*args)
wrangler   File "/opt/locusrobotics/hotdog/dev/ros1/lib/python3/dist-packages/rosmaster/master_api.py", line 579, in param_update_task
wrangler     code, _, _ = xmlrpcapi(caller_api).paramUpdate('/master', param_key, param_value)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1122, in __call__
wrangler     return self.__send(self.__name, args)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1464, in __request
wrangler     response = self.__transport.request(
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1166, in request
wrangler     return self.single_request(host, handler, request_body, verbose)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1178, in single_request
wrangler     http_conn = self.send_request(host, handler, request_body, verbose)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1291, in send_request
wrangler     self.send_content(connection, request_body)
wrangler   File "/usr/lib/python3.10/xmlrpc/client.py", line 1321, in send_content
wrangler     connection.endheaders(request_body)
wrangler   File "/usr/lib/python3.10/http/client.py", line 1278, in endheaders
wrangler     self._send_output(message_body, encode_chunked=encode_chunked)
wrangler   File "/usr/lib/python3.10/http/client.py", line 1038, in _send_output
wrangler     self.send(msg)
wrangler   File "/usr/lib/python3.10/http/client.py", line 976, in send
wrangler     self.connect()
wrangler   File "/usr/lib/python3.10/http/client.py", line 942, in connect
wrangler     self.sock = self._create_connection(
wrangler   File "/usr/lib/python3.10/socket.py", line 845, in create_connection
wrangler     raise err
wrangler   File "/usr/lib/python3.10/socket.py", line 833, in create_connection
wrangler     sock.connect(sa)
wrangler ConnectionRefusedError: [Errno 111] Connection refused
wrangler 
```