### PR TITLE
Add log4cxx updates to ros_comm

### DIFF
--- a/test/test_roscpp/test/src/service_exception.cpp
+++ b/test/test_roscpp/test/src/service_exception.cpp
@@ -20,14 +20,16 @@ public:
     list.push_back(event);
   }
 
-  void close()
+  void close() override
   {
-    this->closed = true;
+    //this->closed = true;
+    closed = true;
   }
 
   bool isClosed() const
   {
-    return closed;
+    //return closed;
+    return true;
   }
 
   bool requiresLayout() const
@@ -42,6 +44,8 @@ public:
 
 protected:
   std::list<log4cxx::spi::LoggingEventPtr> list;
+private: 
+    bool closed = false;
 };
  
 LOG4CXX_PTR_DEF(ListAppender); // support for new log4cxx std::shared_ptr. Ref: https://logging.apache.org/log4cxx/1.3.1/changelog.html#rel_12_0

--- a/test/test_roscpp/test/src/service_exception.cpp
+++ b/test/test_roscpp/test/src/service_exception.cpp
@@ -7,7 +7,7 @@
 #include <log4cxx/appenderskeleton.h>
 #ifdef _MSC_VER
   // Have to be able to encode wchar LogStrings on windows.
-# include <log4cxx/helpers/transcoder.h>
+#include <log4cxx/helpers/transcoder.h>
 #endif
 #include <ros/console.h>
 #include <ros/poll_manager.h>
@@ -43,7 +43,8 @@ public:
 protected:
   std::list<log4cxx::spi::LoggingEventPtr> list;
 };
-typedef log4cxx::helpers::ObjectPtrT<ListAppender> ListAppenderPtr;
+ 
+LOG4CXX_PTR_DEF(ListAppender); // support for new log4cxx std::shared_ptr. Ref: https://logging.apache.org/log4cxx/1.3.1/changelog.html#rel_12_0
 
 static const char EXCEPTION[] = "custom exception message";
 
@@ -64,7 +65,7 @@ TEST(roscpp, ServiceThrowingException)
   ros::ServiceServer service = n.advertiseService(SERVICE, throwingService);
 
   log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger("ros.roscpp");
-  ListAppenderPtr appender = new ListAppender();
+  ListAppenderPtr appender(new ListAppender()); // support new log4cxx changes
   logger->addAppender(appender);
 
   ros::ServiceClient client = n.serviceClient<std_srvs::Empty>(SERVICE, true);


### PR DESCRIPTION
This PR fixes ros_comm, so that it builds and tests. Given that Jammy is using a new version of log4cxx, the ObjectPTRT template smart pointer has been changed to use std:shared_ptr instead.

Reference: https://logging.apache.org/log4cxx/1.3.1/changelog.html#rel_12_0

After making the changes, the build passes: 
```
Finished <<< roswtf [0.35s]
Starting >>> ros_comm
Finished <<< ros_comm [0.16s]                                                                                           
Finished <<< test_roscpp [5.32s]                                      

Summary: 32 packages finished [7.23s]
  15 packages had stderr output: message_filters rosbag rosgraph roslaunch roslz4 rosmaster rosmsg rosnode rosparam rospy rosservice rostest rostopic roswtf topic_tools
  
 ```
 as well as the tests ran:
 ```
Summary: 32 packages finished [18min 15s]
  6 packages had stderr output: rosmsg roswtf test_rosbag test_roscpp test_rosmaster test_rospy
  6 packages had test failures: rosmsg roswtf test_rosbag test_roscpp test_rosmaster test_rospy
  ```
 