### PR TITLE
RST-13777 Add data layer: registrations and param_server

### DIFF
--- a/tools/rosmaster/CMakeLists.txt
+++ b/tools/rosmaster/CMakeLists.txt
@@ -32,6 +32,9 @@ add_library(${PROJECT_NAME}_lib
   src/cpp/names.cpp
   src/cpp/thread_pool.cpp
   src/cpp/validators.cpp
+  src/cpp/registrations.cpp
+  src/cpp/param_server.cpp
+  src/cpp/utilities.cpp
 )
 target_link_libraries(${PROJECT_NAME}_lib
   ${catkin_LIBRARIES}

--- a/tools/rosmaster/include/rosmaster/param_server.h
+++ b/tools/rosmaster/include/rosmaster/param_server.h
@@ -1,0 +1,181 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2025, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef ROSMASTER_PARAM_SERVER_H
+#define ROSMASTER_PARAM_SERVER_H
+
+#include "rosmaster/types.h"
+
+#include <functional>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "xmlrpcpp/XmlRpcValue.h"
+
+namespace rosmaster
+{
+
+class RegistrationManager;
+
+/**
+ * @brief Subscriber update payload: ([(caller_id, caller_api)...], param_key, param_value).
+ */
+struct ParamUpdate
+{
+  ProviderList subscribers;
+  std::string key;
+  XmlRpc::XmlRpcValue value;
+};
+
+using NotifyFunc = std::function<void(const std::vector<ParamUpdate>&)>;
+
+/**
+ * @brief Compute subscriber notifications for a parameter update.
+ * @param subscribers Parameter subscribers registry.
+ * @param param_key Updated parameter key.
+ * @param param_value Updated parameter value.
+ * @param caller_id_to_ignore Caller ID to exclude from notifications.
+ * @return List of grouped parameter updates to dispatch.
+ */
+std::vector<ParamUpdate> computeParamUpdates(
+  const class Registrations& subscribers,
+  const std::string& param_key,
+  const XmlRpc::XmlRpcValue& param_value,
+  const std::string& caller_id_to_ignore = "");
+
+/**
+ * @brief Hierarchical parameter storage with subscriber notifications.
+ */
+class ParamDictionary
+{
+public:
+  /**
+   * @brief Construct a parameter dictionary.
+   * @param reg_manager Registration manager used to track parameter subscribers.
+   */
+  explicit ParamDictionary(RegistrationManager* reg_manager);
+
+  /**
+   * @brief Get the list of all parameter names.
+   * @return All parameter keys currently stored.
+   */
+  std::vector<std::string> getParamNames();
+
+  /**
+   * @brief Search for a parameter from a namespace upward.
+   * @param ns Starting namespace.
+   * @param key Parameter key to search for.
+   * @return Resolved parameter key if found, otherwise an empty string.
+   */
+  std::string searchParam(const std::string& ns, const std::string& key);
+
+  /**
+   * @brief Get a parameter value.
+   * @param key Parameter key.
+   * @return Parameter value.
+   * @throws std::out_of_range If the parameter is not found.
+   */
+  XmlRpc::XmlRpcValue getParam(const std::string& key);
+
+  /**
+   * @brief Set a parameter value with optional subscriber notification.
+   * @param key Parameter key.
+   * @param value Value to store.
+   * @param notify_task Optional callback that dispatches batched notifications.
+   * @param caller_id Caller ID associated with the update.
+   */
+  void setParam(
+    const std::string& key,
+    const XmlRpc::XmlRpcValue& value,
+    NotifyFunc notify_task = nullptr,
+    const std::string& caller_id = "");
+
+  /**
+   * @brief Delete a parameter.
+   * @param key Parameter key.
+   * @param notify_task Optional callback that dispatches batched notifications.
+   * @throws std::out_of_range If the parameter is not found.
+   */
+  void deleteParam(const std::string& key, NotifyFunc notify_task = nullptr);
+
+  /**
+   * @brief Check whether a parameter exists.
+   * @param key Parameter key.
+   * @return True if the parameter exists.
+   */
+  bool hasParam(const std::string& key);
+
+  /**
+   * @brief Subscribe to parameter updates.
+   * @param key Parameter key.
+   * @param caller_id Subscriber caller ID.
+   * @param caller_api Subscriber XML-RPC API URI.
+   * @return Current parameter value.
+   */
+  XmlRpc::XmlRpcValue subscribeParam(
+    const std::string& key,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Unsubscribe from parameter updates.
+   * @param key Parameter key.
+   * @param caller_id Subscriber caller ID.
+   * @param caller_api Subscriber XML-RPC API URI.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> unsubscribeParam(
+    const std::string& key,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+private:
+  /**
+   * @brief Recursively collect parameter names from a dictionary node.
+   * @param names Output vector receiving fully qualified parameter keys.
+   * @param key Current parameter namespace/key prefix.
+   * @param d Dictionary node being traversed.
+   */
+  void getParamNamesImpl(
+    std::vector<std::string>& names,
+    const std::string& key,
+    const XmlRpc::XmlRpcValue& d);
+
+  std::recursive_mutex lock_;
+  XmlRpc::XmlRpcValue parameters_;
+  RegistrationManager* reg_manager_;
+};
+
+}  // namespace rosmaster
+
+#endif  // ROSMASTER_PARAM_SERVER_H

--- a/tools/rosmaster/include/rosmaster/registrations.h
+++ b/tools/rosmaster/include/rosmaster/registrations.h
@@ -1,0 +1,414 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2025, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef ROSMASTER_REGISTRATIONS_H
+#define ROSMASTER_REGISTRATIONS_H
+
+#include "rosmaster/types.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace rosmaster
+{
+
+class MarkedThreadPool;
+
+/**
+ * @brief Container for node registration information.
+ */
+struct NodeRef
+{
+  std::string id;
+  std::string api;
+  std::unordered_set<std::string> param_subscriptions;
+  std::unordered_set<std::string> topic_subscriptions;
+  std::unordered_set<std::string> topic_publications;
+  std::unordered_set<std::string> services;
+
+  /**
+   * @brief Construct an empty node reference.
+   */
+  NodeRef() = default;
+
+  /**
+   * @brief Construct a node reference with a caller ID and API URI.
+   * @param id Node caller ID.
+   * @param api Node XML-RPC API URI.
+   */
+  NodeRef(const std::string& id, const std::string& api) : id(id), api(api) {}
+
+  /**
+   * @brief Clear all registrations tracked by this node reference.
+   */
+  void clear();
+
+  /**
+   * @brief Check whether this node has no registrations in any category.
+   * @return True if all registration sets are empty.
+   */
+  bool isEmpty() const;
+
+  /**
+   * @brief Add a key to the registration set for the given type.
+   * @param type Registration type from Registrations::Type.
+   * @param key Registration key to add.
+   */
+  void add(int type, const std::string& key);
+
+  /**
+   * @brief Remove a key from the registration set for the given type.
+   * @param type Registration type from Registrations::Type.
+   * @param key Registration key to remove.
+   */
+  void remove(int type, const std::string& key);
+};
+
+/**
+ * @class A multimap for storing registrations (publishers, subscribers, services, param subscribers).
+ */
+class Registrations
+{
+public:
+  enum Type
+  {
+    TOPIC_SUBSCRIPTIONS = 1,
+    TOPIC_PUBLICATIONS = 2,
+    SERVICE = 3,
+    PARAM_SUBSCRIPTIONS = 4
+  };
+
+  /**
+   * @brief Construct a registrations table for a specific registration type.
+   * @param type Registration type managed by this table.
+   */
+  explicit Registrations(Type type);
+
+  /**
+   * @brief Check whether there are no registered providers.
+   * @return True if the registration map is empty.
+   */
+  bool empty() const { return map_.empty(); }
+
+  /**
+   * @brief Get all API URIs for a key (not valid for SERVICE type).
+   * @param key Topic or parameter key to query.
+   * @return List of provider API URIs for the key.
+   */
+  std::vector<std::string> getApis(const std::string& key) const;
+
+  /**
+   * @brief Get the service API for a service key.
+   * @param service Service name.
+   * @return Service API URI, or an empty string if not found.
+   */
+  std::string getServiceApi(const std::string& service) const;
+
+  /**
+   * @brief Check whether a key exists in this registration table.
+   * @param key Registration key to check.
+   * @return True if the key exists.
+   */
+  bool hasKey(const std::string& key) const;
+
+  /**
+   * @brief Get (caller_id, caller_api) pairs for a key.
+   * @param key Registration key to query.
+   * @return Provider list associated with the key.
+   */
+  ProviderList getProviders(const std::string& key) const;
+
+  /**
+   * @brief Get state in getSystemState()-friendly format.
+   * @return List of key/provider-name pairs for system state reporting.
+   */
+  std::vector<std::pair<std::string, std::vector<std::string>>> getState() const;
+
+  /**
+   * @brief Get all keys.
+   * @return All registered keys.
+   */
+  std::vector<std::string> getKeys() const;
+
+  /**
+   * @brief Register a provider for a key.
+   * @param key Topic, service, or parameter key.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @param service_api Service API URI when registering services.
+   */
+  void registerProvider(
+    const std::string& key,
+    const std::string& caller_id,
+    const std::string& caller_api,
+    const std::string& service_api = "");
+
+  /**
+   * @brief Remove all registrations belonging to a caller ID.
+   * @param caller_id Node caller ID to purge.
+   */
+  void unregisterAll(const std::string& caller_id);
+
+  /**
+   * @brief Unregister a provider for a key.
+   * @param key Topic, service, or parameter key.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @param service_api Service API URI for service unregistration.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> unregister(
+    const std::string& key,
+    const std::string& caller_id,
+    const std::string& caller_api,
+    const std::string& service_api = "");
+
+  /**
+   * @brief Get the registration type managed by this instance.
+   * @return Registration type enum value.
+   */
+  Type getType() const { return type_; }
+
+private:
+  Type type_;
+
+  // Map of key -> list of providers (caller_id, caller_api)
+  std::unordered_map<std::string, ProviderList> map_;
+
+  // Map of key->service_api for SERVICE type (for O(1) lookup during unregister)
+  std::unordered_map<std::string, ServiceProvider> service_api_map_;
+};
+
+/**
+ * @class Central registration tracker for the master.
+ */
+class RegistrationManager
+{
+public:
+  /**
+   * @brief Construct a registration manager.
+   * @param thread_pool Thread pool used for asynchronous operations.
+   */
+  explicit RegistrationManager(MarkedThreadPool* thread_pool);
+
+  /**
+   * @brief Register a node as a parameter subscriber.
+   * @param param Parameter key.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   */
+  void registerParamSubscriber(
+    const std::string& param,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Register a node as a topic publisher.
+   * @param topic Topic name.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   */
+  void registerPublisher(
+    const std::string& topic,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Register a service provider.
+   * @param service Service name.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @param service_api Service API URI.
+   */
+  void registerService(
+    const std::string& service,
+    const std::string& caller_id,
+    const std::string& caller_api,
+    const std::string& service_api);
+
+  /**
+   * @brief Register a node as a topic subscriber.
+   * @param topic Topic name.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   */
+  void registerSubscriber(
+    const std::string& topic,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Unregister a parameter subscriber.
+   * @param param Parameter key.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> unregisterParamSubscriber(
+    const std::string& param,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Unregister a topic publisher.
+   * @param topic Topic name.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> unregisterPublisher(
+    const std::string& topic,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Unregister a service provider.
+   * @param service Service name.
+   * @param caller_id Node caller ID.
+   * @param service_api Service API URI.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> unregisterService(
+    const std::string& service,
+    const std::string& caller_id,
+    const std::string& service_api);
+
+  /**
+   * @brief Unregister a topic subscriber.
+   * @param topic Topic name.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> unregisterSubscriber(
+    const std::string& topic,
+    const std::string& caller_id,
+    const std::string& caller_api);
+
+  /**
+   * @brief Find a tracked node by caller ID.
+   * @param caller_id Node caller ID.
+   * @return Pointer to the node reference, or null if unknown.
+   */
+  NodeRef* getNode(const std::string& caller_id);
+
+  /**
+   * @brief Access parameter subscriber registrations.
+   * @return Mutable parameter subscriber registration table.
+   */
+  Registrations& getParamSubscribers();
+
+  /**
+   * @brief Access publisher registrations.
+   * @return Mutable publisher registration table.
+   */
+  Registrations& getPublishers();
+
+  /**
+   * @brief Access service registrations.
+   * @return Mutable service registration table.
+   */
+  Registrations& getServices();
+
+  /**
+   * @brief Access subscriber registrations.
+   * @return Mutable subscriber registration table.
+   */
+  Registrations& getSubscribers();
+
+  /**
+   * @brief Reverse lookup: find nodes by their API URI.
+   * @param caller_api Node XML-RPC API URI.
+   * @return Node references that use the specified API URI.
+   */
+  std::vector<NodeRef*> reverseLookup(const std::string& caller_api);
+  
+private:
+  /**
+   * @brief Register or update a node's API.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @return Pair of node reference pointer and whether the API changed.
+   */
+  std::pair<NodeRef*, bool> registerNodeApi(const std::string& caller_id, const std::string& caller_api);
+
+  /**
+   * @brief Internal helper to add a registration and update node bookkeeping.
+   * @param r Registration table to update.
+   * @param key Topic, service, or parameter key.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @param service_api Service API URI for service registrations.
+   */
+  void doRegister(
+    Registrations& r,
+    const std::string& key,
+    const std::string& caller_id,
+    const std::string& caller_api,
+    const std::string& service_api = "");
+
+  /**
+   * @brief Internal helper to remove a registration and update node bookkeeping.
+   * @param r Registration table to update.
+   * @param key Topic, service, or parameter key.
+   * @param caller_id Node caller ID.
+   * @param caller_api Node XML-RPC API URI.
+   * @param service_api Service API URI for service unregistrations.
+   * @return Tuple of status code, status message, and unregistered count.
+   */
+  std::tuple<int, std::string, int> doUnregister(
+    Registrations& r,
+    const std::string& key,
+    const std::string& caller_id,
+    const std::string& caller_api,
+    const std::string& service_api = "");
+
+  Registrations publishers_;
+  Registrations subscribers_;
+  Registrations services_;
+  Registrations param_subscribers_;
+
+  std::unordered_map<std::string, NodeRef> nodes_;
+
+  MarkedThreadPool* thread_pool_;
+
+  // Reverse index: api_uri -> set of node_ids (for O(1) reverseLookup)
+  std::unordered_map<std::string, std::unordered_set<std::string>> api_to_nodes_;
+};
+
+}  // namespace rosmaster
+
+#endif  // ROSMASTER_REGISTRATIONS_H

--- a/tools/rosmaster/include/rosmaster/types.h
+++ b/tools/rosmaster/include/rosmaster/types.h
@@ -1,0 +1,50 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2026, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef ROSMASTER_TYPES_H
+#define ROSMASTER_TYPES_H
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace rosmaster
+{
+
+using Provider = std::pair<std::string, std::string>;  // (caller_id, caller_api)
+using ProviderList = std::vector<Provider>;
+
+using ServiceProvider = std::pair<std::string, std::string>;  // (caller_id, server_api)
+
+}  // namespace rosmaster
+
+#endif  // ROSMASTER_TYPES_H

--- a/tools/rosmaster/include/rosmaster/utilities.h
+++ b/tools/rosmaster/include/rosmaster/utilities.h
@@ -1,0 +1,52 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2026, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef ROSMASTER_UTILITIES_H
+#define ROSMASTER_UTILITIES_H
+
+#include <string>
+#include <vector>
+
+namespace rosmaster
+{
+
+/**
+ * @brief Utility function to split string by delimiter
+ * @param str The string to split
+ * @param delimiter The character to split by
+ * @return A vector of non-empty parts
+ */
+std::vector<std::string> splitString(const std::string& str, char delimiter);
+
+}  // namespace rosmaster
+
+#endif  // ROSMASTER_UTILITIES_H

--- a/tools/rosmaster/src/cpp/names.cpp
+++ b/tools/rosmaster/src/cpp/names.cpp
@@ -31,34 +31,18 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "rosmaster/names.h"
+#include "rosmaster/utilities.h"
 
 #include <algorithm>
 #include <regex>
 #include <sstream>
 #include <vector>
 
+
 namespace rosmaster
 {
 namespace names
 {
-
-namespace
-{
-std::vector<std::string> splitName(const std::string& name, char sep)
-{
-  std::vector<std::string> parts;
-  std::istringstream stream(name);
-  std::string part;
-  while (std::getline(stream, part, sep))
-  {
-    if (!part.empty())
-    {
-      parts.push_back(part);
-    }
-  }
-  return parts;
-}
-}  // anonymous namespace
 
 std::string getNamespace(const std::string& name)
 {
@@ -106,7 +90,7 @@ std::string canonicalizeName(const std::string& name)
   {
     return name;
   }
-  auto parts = splitName(name, SEP);
+  auto parts = splitString(name, SEP);
   std::string result;
   if (name[0] == SEP)
   {

--- a/tools/rosmaster/src/cpp/param_server.cpp
+++ b/tools/rosmaster/src/cpp/param_server.cpp
@@ -1,0 +1,528 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2025, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "rosmaster/param_server.h"
+#include "rosmaster/names.h"
+#include "rosmaster/registrations.h"
+#include "rosmaster/utilities.h"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_set>
+#include <vector>
+
+namespace rosmaster
+{
+
+namespace
+{
+
+/**
+ * @brief Recursively remove internal TypeInvalid placeholder entries from XmlRpcValue structs.
+ * @details Placeholder entries (TypeInvalid value) are used internally to force TypeStruct
+ * promotion on empty namespaces. Only entries with TypeInvalid values are stripped, so user
+ * parameters whose keys happen to match placeholder names are preserved.
+ * structToXml() already skips TypeInvalid members, so placeholders won't appear in XML.
+ * @param src XmlRpc value to sanitize.
+ * @return XmlRpc value with internal placeholder entries removed.
+ */
+XmlRpc::XmlRpcValue stripPlaceholders(const XmlRpc::XmlRpcValue& src)
+{
+  if (src.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    return src;
+  }
+  XmlRpc::XmlRpcValue result;
+  bool has_real_key = false;
+  for (auto it = src.begin(); it != src.end(); ++it)
+  {
+    if (it->second.getType() == XmlRpc::XmlRpcValue::TypeInvalid)
+    {
+      continue;
+    }
+    result[it->first] = stripPlaceholders(it->second);
+    has_real_key = true;
+  }
+  if (!has_real_key)
+  {
+    // Force TypeStruct promotion. The resulting __placeholder__ entry has
+    // TypeInvalid value, which structToXml() will skip (see XmlRpcValue.cpp).
+    result["__placeholder__"];
+  }
+  return result;
+}
+
+/**
+ * @brief Collect all parameter keys contained in a nested XmlRpc struct.
+ * @param param_key Current parameter namespace prefix.
+ * @param param_value Parameter value to traverse.
+ * @param all_keys Output set of discovered keys.
+ */
+void computeAllKeys(
+  const std::string& param_key,
+  const XmlRpc::XmlRpcValue& param_value,
+  std::unordered_set<std::string>& all_keys)
+{
+  if (param_value.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    return;
+  }
+  for (auto it = param_value.begin(); it != param_value.end(); ++it)
+  {
+    if (it->second.getType() == XmlRpc::XmlRpcValue::TypeInvalid)
+    {
+      continue;
+    }
+    std::string new_k = names::nsJoin(param_key, it->first) + "/";
+    all_keys.insert(new_k);
+    if (it->second.getType() == XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      computeAllKeys(new_k, it->second, all_keys);
+    }
+  }
+}
+
+}  // anonymous namespace
+
+std::vector<ParamUpdate> computeParamUpdates(
+  const Registrations& subscribers,
+  const std::string& param_key,
+  const XmlRpc::XmlRpcValue& param_value,
+  const std::string& caller_id_to_ignore)
+{
+  if (subscribers.empty())
+  {
+    return {};
+  }
+
+  std::string pk = param_key;
+  if (pk != "/")
+  {
+    pk = names::canonicalizeName(pk) + "/";
+  }
+
+  // Compute all updated keys if value is a dict
+  std::unordered_set<std::string> all_keys;
+  bool has_all_keys = false;
+  if (param_value.getType() == XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    computeAllKeys(pk, param_value, all_keys);
+    has_all_keys = true;
+  }
+
+  std::vector<ParamUpdate> updates;
+
+  for (const auto& sub_key : subscribers.getKeys())
+  {
+    std::string ns_key = sub_key;
+    if (ns_key.empty() || ns_key.back() != '/')
+    {
+      ns_key += "/";
+    }
+
+    if (pk.substr(0, ns_key.size()) == ns_key)
+    {
+      // Subscriber's namespace is a prefix of the updated key
+      auto node_apis = subscribers.getProviders(sub_key);
+      if (!caller_id_to_ignore.empty())
+      {
+        node_apis.erase(
+            std::remove_if(node_apis.begin(), node_apis.end(),
+                           [&](const auto& p) { return p.first == caller_id_to_ignore; }),
+            node_apis.end());
+      }
+      ParamUpdate update;
+      update.subscribers = std::move(node_apis);
+      update.key = pk;
+      update.value = param_value;
+      updates.push_back(std::move(update));
+    }
+    else if (has_all_keys && ns_key.substr(0, pk.size()) == pk)
+    {
+      // Check if subscription was deleted (key is within the param namespace but not in new value)
+      if (all_keys.count(ns_key) == 0)
+      {
+        auto node_apis = subscribers.getProviders(sub_key);
+        ParamUpdate update;
+        update.subscribers = std::move(node_apis);
+        update.key = sub_key;
+
+        // Signal parameter deletion with an empty struct {}, matching Python rosmaster behaviour.
+        // We promote to TypeStruct via a sentinel key set to TypeInvalid; structToXml skips
+        // TypeInvalid members, so this serialises as <struct></struct> = {}.
+        update.value["__empty__"] = XmlRpc::XmlRpcValue();
+        updates.push_back(std::move(update));
+      }
+    }
+  }
+
+  // Add updates for exact matches within tree
+  if (has_all_keys)
+  {
+    for (const auto& key : all_keys)
+    {
+      if (subscribers.hasKey(key))
+      {
+        // Compute actual update value by navigating into param_value
+        std::string sub_key = key.substr(pk.size());
+        auto ns_parts = splitString(sub_key, '/');
+        XmlRpc::XmlRpcValue val = param_value;
+        for (const auto& ns : ns_parts)
+        {
+          if (val.getType() == XmlRpc::XmlRpcValue::TypeStruct && val.hasMember(ns))
+          {
+            val = val[ns];
+          }
+          else
+          {
+            break;
+          }
+        }
+        ParamUpdate update;
+        update.subscribers = subscribers.getProviders(key);
+        update.key = key;
+        update.value = val;
+        updates.push_back(std::move(update));
+      }
+    }
+  }
+
+  return updates;
+}
+
+ParamDictionary::ParamDictionary(RegistrationManager* reg_manager) : reg_manager_(reg_manager)
+{
+  // Initialize parameters_ as a struct by accessing a key.
+  // XmlRpcValue operator[] with string key auto-promotes to TypeStruct.
+  parameters_["__placeholder__"];
+}
+
+void ParamDictionary::getParamNamesImpl(std::vector<std::string>& names, const std::string& key,
+                                         const XmlRpc::XmlRpcValue& d)
+{
+  if (d.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    return;
+  }
+  for (auto it = d.begin(); it != d.end(); ++it)
+  {
+    // Skip internal TypeInvalid placeholder entries
+    if (it->second.getType() == XmlRpc::XmlRpcValue::TypeInvalid)
+    {
+      continue;
+    }
+    std::string full_key = names::nsJoin(key, it->first);
+    if (it->second.getType() == XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      getParamNamesImpl(names, full_key, it->second);
+    }
+    else
+    {
+      names.push_back(full_key);
+    }
+  }
+}
+
+std::vector<std::string> ParamDictionary::getParamNames()
+{
+  std::lock_guard<std::recursive_mutex> lock(lock_);
+  std::vector<std::string> param_names;
+  getParamNamesImpl(param_names, "/", parameters_);
+  return param_names;
+}
+
+std::string ParamDictionary::searchParam(const std::string& ns, const std::string& key)
+{
+  if (key.empty() || names::isPrivate(key))
+  {
+    return {};
+  }
+  if (!names::isGlobal(ns))
+  {
+    return {};
+  }
+  if (names::isGlobal(key))
+  {
+    if (hasParam(key))
+    {
+      return key;
+    }
+    return {};
+  }
+
+  // Get the first namespace component of the key
+  auto parts = splitString(key, '/');
+  if (parts.empty())
+  {
+    return {};
+  }
+  std::string key_ns = parts[0];
+
+  // Test initial namespace
+  std::string search_key = names::nsJoin(ns, key_ns);
+  if (hasParam(search_key))
+  {
+    return names::nsJoin(ns, key);
+  }
+
+  // Walk up the namespace tree
+  auto ns_parts = splitString(ns, '/');
+  for (size_t i = 1; i <= ns_parts.size(); ++i)
+  {
+    std::string prefix = "/";
+    for (size_t j = 0; j < ns_parts.size() - i; ++j)
+    {
+      prefix += ns_parts[j] + "/";
+    }
+    search_key = prefix + key_ns;
+    if (hasParam(search_key))
+    {
+      return prefix + key;
+    }
+  }
+  return {};
+}
+
+XmlRpc::XmlRpcValue ParamDictionary::getParam(const std::string& key)
+{
+  std::lock_guard<std::recursive_mutex> lock(lock_);
+
+  if (key == names::GLOBALNS)
+  {
+    return stripPlaceholders(parameters_);
+  }
+
+  auto ns_parts = splitString(key, '/');
+
+  // Use a pointer to walk the tree to avoid self-assignment issues
+  const XmlRpc::XmlRpcValue* d = &parameters_;
+  for (const auto& ns : ns_parts)
+  {
+    if (d->getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      throw std::out_of_range("Parameter [" + key + "] is not set");
+    }
+    if (!d->hasMember(ns))
+    {
+      throw std::out_of_range("Parameter [" + key + "] is not set");
+    }
+    d = &((*d)[ns]);
+  }
+  return stripPlaceholders(*d);
+}
+
+void ParamDictionary::setParam(
+  const std::string& key,
+  const XmlRpc::XmlRpcValue& value,
+  NotifyFunc notify_task,
+  const std::string& caller_id)
+{
+  std::lock_guard<std::recursive_mutex> lock(lock_);
+
+  if (key == names::GLOBALNS)
+  {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      throw std::runtime_error("cannot set root of parameter tree to non-dictionary");
+    }
+    parameters_ = value;
+  }
+  else
+  {
+    auto ns_parts = splitString(key, '/');
+    if (ns_parts.empty())
+    {
+      return;
+    }
+    std::string value_key = ns_parts.back();
+    ns_parts.pop_back();
+
+    // Ensure parameters_ is a struct
+    if (!parameters_.valid() || parameters_.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      // Force struct type by accessing a key. We use the actual first key we need.
+      parameters_[ns_parts.empty() ? value_key : ns_parts[0]];
+    }
+
+    // Navigate/create the namespace tree
+    XmlRpc::XmlRpcValue* d = &parameters_;
+    for (const auto& ns : ns_parts)
+    {
+      if (!d->hasMember(ns) || (*d)[ns].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+      {
+        // Accessing a non-existent key on a struct auto-creates it as invalid.
+        // We need to explicitly make it a struct by accessing a sub-key.
+        (*d)[ns]["__placeholder__"];
+      }
+      d = &((*d)[ns]);
+    }
+    (*d)[value_key] = value;
+  }
+
+  if (notify_task)
+  {
+    auto updates = computeParamUpdates(reg_manager_->getParamSubscribers(), key, value, caller_id);
+    if (!updates.empty())
+    {
+      notify_task(updates);
+    }
+  }
+}
+
+void ParamDictionary::deleteParam(const std::string& key, NotifyFunc notify_task)
+{
+  std::lock_guard<std::recursive_mutex> lock(lock_);
+
+  if (key == names::GLOBALNS)
+  {
+    throw std::out_of_range("cannot delete root of parameter tree");
+  }
+
+  auto ns_parts = splitString(key, '/');
+  if (ns_parts.empty())
+  {
+    throw std::out_of_range("Parameter [" + key + "] is not set");
+  }
+  std::string value_key = ns_parts.back();
+  ns_parts.pop_back();
+
+  XmlRpc::XmlRpcValue* d = &parameters_;
+  for (const auto& ns : ns_parts)
+  {
+    if (d->getType() != XmlRpc::XmlRpcValue::TypeStruct || !d->hasMember(ns))
+    {
+      throw std::out_of_range("Parameter [" + key + "] is not set");
+    }
+    d = &((*d)[ns]);
+  }
+
+  if (!d->hasMember(value_key))
+  {
+    throw std::out_of_range("Parameter [" + key + "] is not set");
+  }
+
+  // XmlRpcValue doesn't have a remove member method, so we rebuild without the key
+  XmlRpc::XmlRpcValue new_d;
+  bool has_other = false;
+  for (auto it = d->begin(); it != d->end(); ++it)
+  {
+    if (it->first != value_key)
+    {
+      new_d[it->first] = it->second;
+      has_other = true;
+    }
+  }
+  if (has_other)
+  {
+    *d = new_d;
+  }
+  else
+  {
+    // Set to empty struct using a TypeInvalid placeholder (stripped by stripPlaceholders,
+    // skipped by structToXml). Using TypeInvalid avoids reserving any user-visible key name.
+    d->clear();
+    (*d)["__init__"];
+  }
+
+  if (notify_task)
+  {
+    // Signal deletion with an empty struct {} (TypeInvalid sentinel, skipped by structToXml).
+    XmlRpc::XmlRpcValue empty_val;
+    empty_val["__empty__"] = XmlRpc::XmlRpcValue();
+    auto updates = computeParamUpdates(reg_manager_->getParamSubscribers(), key, empty_val);
+    if (!updates.empty())
+    {
+      notify_task(updates);
+    }
+  }
+}
+
+bool ParamDictionary::hasParam(const std::string& key)
+{
+  try
+  {
+    auto val = getParam(key);
+    // Don't count internal placeholders as real params
+    if (val.getType() == XmlRpc::XmlRpcValue::TypeInvalid)
+    {
+      return false;
+    }
+    return true;
+  }
+  catch (const std::out_of_range&)
+  {
+    return false;
+  }
+}
+
+XmlRpc::XmlRpcValue ParamDictionary::subscribeParam(
+  const std::string& key,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  std::string k = key;
+  if (k != "/")
+  {
+    k = names::canonicalizeName(k) + "/";
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(lock_);
+  XmlRpc::XmlRpcValue val;
+  try
+  {
+    val = getParam(k);
+  }
+  catch (const std::out_of_range&)
+  {
+    // Parameter not set yet - return empty dict using a TypeInvalid placeholder
+    val = XmlRpc::XmlRpcValue();
+    val["__empty__"];
+  }
+  reg_manager_->registerParamSubscriber(k, caller_id, caller_api);
+  return stripPlaceholders(val);
+}
+
+std::tuple<int, std::string, int> ParamDictionary::unsubscribeParam(
+  const std::string& key,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  std::string k = key;
+  if (k != "/")
+  {
+    k = names::canonicalizeName(k) + "/";
+  }
+  return reg_manager_->unregisterParamSubscriber(k, caller_id, caller_api);
+}
+
+}  // namespace rosmaster

--- a/tools/rosmaster/src/cpp/registrations.cpp
+++ b/tools/rosmaster/src/cpp/registrations.cpp
@@ -1,0 +1,548 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2025, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "rosmaster/registrations.h"
+#include "rosmaster/thread_pool.h"
+#include "rosmaster/types.h"
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+
+#include "xmlrpcpp/XmlRpcClient.h"
+#include "xmlrpcpp/XmlRpcValue.h"
+
+namespace rosmaster
+{
+
+void NodeRef::clear()
+{
+  param_subscriptions.clear();
+  topic_subscriptions.clear();
+  topic_publications.clear();
+  services.clear();
+}
+
+bool NodeRef::isEmpty() const
+{
+  return param_subscriptions.empty() && topic_subscriptions.empty() && topic_publications.empty() &&
+         services.empty();
+}
+
+void NodeRef::add(int type, const std::string& key)
+{
+  switch (type)
+  {
+    case Registrations::TOPIC_SUBSCRIPTIONS:
+      topic_subscriptions.insert(key);
+      break;
+    case Registrations::TOPIC_PUBLICATIONS:
+      topic_publications.insert(key);
+      break;
+    case Registrations::SERVICE:
+      services.insert(key);
+      break;
+    case Registrations::PARAM_SUBSCRIPTIONS:
+      param_subscriptions.insert(key);
+      break;
+    default:
+      throw std::runtime_error("NodeRef::add: invalid registration type");
+  }
+}
+
+void NodeRef::remove(int type, const std::string& key)
+{
+  switch (type)
+  {
+    case Registrations::TOPIC_SUBSCRIPTIONS:
+      topic_subscriptions.erase(key);
+      break;
+    case Registrations::TOPIC_PUBLICATIONS:
+      topic_publications.erase(key);
+      break;
+    case Registrations::SERVICE:
+      services.erase(key);
+      break;
+    case Registrations::PARAM_SUBSCRIPTIONS:
+      param_subscriptions.erase(key);
+      break;
+    default:
+      throw std::runtime_error("NodeRef::remove: invalid registration type");
+  }
+}
+
+static void shutdownNodeTask(
+  const std::string& api,
+  const std::string& caller_id,
+  const std::string& reason)
+{
+  try
+  {
+    // Parse URI: http://host:port/
+    std::string host;
+    int port = 0;
+    std::string uri_path = "/";
+    if (api.substr(0, 7) == "http://")
+    {
+      auto rest = api.substr(7);
+      auto slash_pos = rest.find('/');
+      std::string host_port = (slash_pos != std::string::npos) ? rest.substr(0, slash_pos) : rest;
+      if (slash_pos != std::string::npos)
+      {
+        uri_path = rest.substr(slash_pos);
+      }
+      auto colon_pos = host_port.rfind(':');
+      if (colon_pos != std::string::npos)
+      {
+        host = host_port.substr(0, colon_pos);
+        port = std::stoi(host_port.substr(colon_pos + 1));
+      }
+    }
+    if (host.empty() || port == 0)
+    {
+      return;
+    }
+
+    XmlRpc::XmlRpcClient client(host.c_str(), port, uri_path.c_str());
+    XmlRpc::XmlRpcValue params;
+    params[0] = "/master";
+    params[1] = "[" + caller_id + "] Reason: " + reason;
+    XmlRpc::XmlRpcValue result;
+    client.execute("shutdown", params, result);
+  }
+  catch (...)
+  {
+    // Expected in many common cases
+  }
+}
+
+Registrations::Registrations(Type type) : type_(type)
+{
+}
+
+std::vector<std::string> Registrations::getApis(const std::string& key) const
+{
+  std::vector<std::string> apis;
+  auto it = map_.find(key);
+  if (it != map_.end())
+  {
+    for (const auto& provider : it->second)
+    {
+      apis.push_back(provider.second);
+    }
+  }
+  return apis;
+}
+
+std::string Registrations::getServiceApi(const std::string& service) const
+{
+  auto it = service_api_map_.find(service);
+  if (it != service_api_map_.end())
+  {
+    return it->second.second;
+  }
+  return {};
+}
+
+bool Registrations::hasKey(const std::string& key) const
+{
+  return map_.find(key) != map_.end();
+}
+
+ProviderList Registrations::getProviders(const std::string& key) const
+{
+  auto it = map_.find(key);
+  if (it != map_.end())
+  {
+    return it->second;
+  }
+  return {};
+}
+
+std::vector<std::pair<std::string, std::vector<std::string>>> Registrations::getState() const
+{
+  std::vector<std::pair<std::string, std::vector<std::string>>> retval;
+  for (const auto& kv : map_)
+  {
+    std::vector<std::string> ids;
+    for (const auto& provider : kv.second)
+    {
+      ids.push_back(provider.first);
+    }
+    retval.emplace_back(kv.first, std::move(ids));
+  }
+  return retval;
+}
+
+std::vector<std::string> Registrations::getKeys() const
+{
+  std::vector<std::string> keys;
+  keys.reserve(map_.size());
+
+  for (const auto& kv : map_)
+  {
+    keys.push_back(kv.first);
+  }
+
+  return keys;
+}
+
+void Registrations::registerProvider(
+  const std::string& key,
+  const std::string& caller_id,
+  const std::string& caller_api,
+  const std::string& service_api)
+{
+  Provider entry{caller_id, caller_api};
+
+  auto it = map_.find(key);
+  if (it != map_.end() && service_api.empty())
+  {
+    auto& providers = it->second;
+
+    // ProviderLists are typically very small (1-3 entries per topic)
+    // so linear search is fine; avoiding overhead of a set
+    bool found = false;
+    for (const auto& p : providers)
+    {
+      if (p == entry) { found = true; break; }
+    }
+    if (!found)
+    {
+      providers.push_back(std::move(entry));
+    }
+  }
+  else
+  {
+    map_[key] = {entry};
+  }
+
+  if (!service_api.empty())
+  {
+    service_api_map_[key] = ServiceProvider{caller_id, service_api};
+  }
+  else if (type_ == SERVICE)
+  {
+    throw std::runtime_error("service_api must be specified for SERVICE registrations");
+  }
+}
+
+void Registrations::unregisterAll(const std::string& caller_id)
+{
+  std::vector<std::string> dead_keys;
+  for (auto& kv : map_)
+  {
+    auto& providers = kv.second;
+    providers.erase(std::remove_if(providers.begin(), providers.end(),
+                                   [&](const Provider& p) { return p.first == caller_id; }),
+                    providers.end());
+    if (providers.empty())
+    {
+      dead_keys.push_back(kv.first);
+    }
+  }
+  for (const auto& k : dead_keys)
+  {
+    map_.erase(k);
+  }
+
+  if (type_ == SERVICE)
+  {
+    dead_keys.clear();
+    for (const auto& kv : service_api_map_)
+    {
+      if (kv.second.first == caller_id)
+      {
+        dead_keys.push_back(kv.first);
+      }
+    }
+    for (const auto& k : dead_keys)
+    {
+      service_api_map_.erase(k);
+    }
+  }
+}
+
+std::tuple<int, std::string, int> Registrations::unregister(
+  const std::string& key,
+  const std::string& caller_id,
+  const std::string& caller_api,
+  const std::string& service_api)
+{
+  if (!service_api.empty())
+  {
+    // Service unregistration: validate against service_api
+    auto it = service_api_map_.find(key);
+    if (it == service_api_map_.end())
+    {
+      return {1, "[" + caller_id + "] is not a provider of [" + key + "]", 0};
+    }
+    if (it->second != ServiceProvider{caller_id, service_api})
+    {
+      return {1, "[" + service_api + "] is no longer the current service api handle for [" + key + "]", 0};
+    }
+    service_api_map_.erase(key);
+    map_.erase(key);
+    return {1, "Unregistered [" + caller_id + "] as provider of [" + key + "]", 1};
+  }
+  else if (type_ == SERVICE)
+  {
+    throw std::runtime_error("service_api must be specified for SERVICE unregistration");
+  }
+
+  auto map_it = map_.find(key);
+  if (map_it != map_.end())
+  {
+    auto& providers = map_it->second;
+    Provider entry{caller_id, caller_api};
+    auto it = std::find(providers.begin(), providers.end(), entry);
+    if (it != providers.end())
+    {
+      providers.erase(it);
+      if (providers.empty())
+      {
+        map_.erase(map_it);
+      }
+      return {1, "Unregistered [" + caller_id + "] as provider of [" + key + "]", 1};
+    }
+  }
+  return {1, "[" + caller_id + "] is not a known provider of [" + key + "]", 0};
+}
+
+RegistrationManager::RegistrationManager(MarkedThreadPool* thread_pool)
+  : publishers_(Registrations::TOPIC_PUBLICATIONS)
+  , subscribers_(Registrations::TOPIC_SUBSCRIPTIONS)
+  , services_(Registrations::SERVICE)
+  , param_subscribers_(Registrations::PARAM_SUBSCRIPTIONS)
+  , thread_pool_(thread_pool)
+{
+}
+
+void RegistrationManager::registerService(
+  const std::string& service,
+  const std::string& caller_id,
+  const std::string& caller_api,
+  const std::string& service_api)
+{
+  doRegister(services_, service, caller_id, caller_api, service_api);
+}
+
+void RegistrationManager::registerPublisher(
+  const std::string& topic,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  doRegister(publishers_, topic, caller_id, caller_api);
+}
+
+void RegistrationManager::registerSubscriber(
+  const std::string& topic,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  doRegister(subscribers_, topic, caller_id, caller_api);
+}
+
+void RegistrationManager::registerParamSubscriber(
+  const std::string& param,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  doRegister(param_subscribers_, param, caller_id, caller_api);
+}
+
+std::tuple<int, std::string, int>
+RegistrationManager::unregisterService(
+  const std::string& service,
+  const std::string& caller_id,
+  const std::string& service_api)
+{
+  return doUnregister(services_, service, caller_id, "", service_api);
+}
+
+std::tuple<int, std::string, int>
+RegistrationManager::unregisterSubscriber(
+  const std::string& topic,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  return doUnregister(subscribers_, topic, caller_id, caller_api);
+}
+
+std::tuple<int, std::string, int>
+RegistrationManager::unregisterPublisher(
+  const std::string& topic,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  return doUnregister(publishers_, topic, caller_id, caller_api);
+}
+
+std::tuple<int, std::string, int>
+RegistrationManager::unregisterParamSubscriber(
+  const std::string& param,
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  return doUnregister(param_subscribers_, param, caller_id, caller_api);
+}
+
+NodeRef* RegistrationManager::getNode(const std::string& caller_id)
+{
+  auto it = nodes_.find(caller_id);
+  if (it != nodes_.end())
+  {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+Registrations& RegistrationManager::getPublishers()
+{
+  return publishers_;
+}
+
+Registrations& RegistrationManager::getSubscribers()
+{
+  return subscribers_;
+}
+
+Registrations& RegistrationManager::getServices()
+{
+  return services_;
+}
+
+Registrations& RegistrationManager::getParamSubscribers()
+{
+  return param_subscribers_;
+}
+
+std::vector<NodeRef*> RegistrationManager::reverseLookup(const std::string& caller_api)
+{
+  std::vector<NodeRef*> matches;
+  auto it = api_to_nodes_.find(caller_api);
+  if (it != api_to_nodes_.end())
+  {
+    for (const auto& node_id : it->second)
+    {
+      auto nit = nodes_.find(node_id);
+      if (nit != nodes_.end())
+      {
+        matches.push_back(&nit->second);
+      }
+    }
+  }
+  return matches;
+}
+
+std::pair<NodeRef*, bool> RegistrationManager::registerNodeApi(
+  const std::string& caller_id,
+  const std::string& caller_api)
+{
+  auto it = nodes_.find(caller_id);
+  if (it != nodes_.end())
+  {
+    if (it->second.api == caller_api)
+    {
+      return {&it->second, false};
+    }
+    // Node re-registered with different API - update reverse index and shut down old node
+    std::string bumped_api = it->second.api;
+    api_to_nodes_[bumped_api].erase(caller_id);
+    if (api_to_nodes_[bumped_api].empty())
+    {
+      api_to_nodes_.erase(bumped_api);
+    }
+    if (thread_pool_)
+    {
+      std::string cid = caller_id;
+      thread_pool_->queueTask(bumped_api, [bumped_api, cid]() {
+        shutdownNodeTask(bumped_api, cid, "new node registered with same name");
+      });
+    }
+  }
+  nodes_[caller_id] = NodeRef(caller_id, caller_api);
+  api_to_nodes_[caller_api].insert(caller_id);
+  return {&nodes_[caller_id], it != nodes_.end()};
+}
+
+void RegistrationManager::doRegister(
+  Registrations& r,
+  const std::string& key,
+  const std::string& caller_id,
+  const std::string& caller_api,
+  const std::string& service_api)
+{
+  auto [node_ref, changed] = registerNodeApi(caller_id, caller_api);
+  node_ref->add(r.getType(), key);
+  if (changed)
+  {
+    publishers_.unregisterAll(caller_id);
+    subscribers_.unregisterAll(caller_id);
+    services_.unregisterAll(caller_id);
+    param_subscribers_.unregisterAll(caller_id);
+  }
+  r.registerProvider(key, caller_id, caller_api, service_api);
+}
+
+std::tuple<int, std::string, int>
+RegistrationManager::doUnregister(
+  Registrations& r,
+  const std::string& key,
+  const std::string& caller_id,
+  const std::string& caller_api,
+  const std::string& service_api)
+{
+  auto it = nodes_.find(caller_id);
+  if (it != nodes_.end())
+  {
+    auto retval = r.unregister(key, caller_id, caller_api, service_api);
+    if (std::get<2>(retval) == 1)
+    {
+      it->second.remove(r.getType(), key);
+    }
+    if (it->second.isEmpty())
+    {
+      std::string api = it->second.api;
+      api_to_nodes_[api].erase(caller_id);
+      if (api_to_nodes_[api].empty())
+      {
+        api_to_nodes_.erase(api);
+      }
+      nodes_.erase(it);
+    }
+    return retval;
+  }
+  return {1, "[" + caller_id + "] is not a registered node", 0};
+}
+
+}  // namespace rosmaster

--- a/tools/rosmaster/src/cpp/utilities.cpp
+++ b/tools/rosmaster/src/cpp/utilities.cpp
@@ -1,0 +1,57 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2026, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "rosmaster/utilities.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace rosmaster
+{
+
+std::vector<std::string> splitString(const std::string& str, char delimiter)
+{
+  std::vector<std::string> parts;
+  std::istringstream stream(str);
+  std::string part;
+  while (std::getline(stream, part, delimiter))
+  {
+    if (!part.empty())
+    {
+      parts.push_back(part);
+    }
+  }
+  return parts;
+}
+
+}  // namespace rosmaster


### PR DESCRIPTION
https://locusrobotics.atlassian.net/browse/RST-13777

PR 2 of 5: add the state management modules for the C++ rosmaster

- `registrations.h/cpp`: NodeRef, Registrations, RegistrationManager with reverse-index lookups (api_to_nodes_), unordered_map/set for O(1) ops, and thread-pool integration for subscriber notifications.
- `param_server.h/cpp`: Hierarchical parameter storage using XmlRpcValue structs, with sentinel key management (isSentinelKey, stripPlaceholders), param subscription/notification support, and computeParamUpdates.

This class was initially developed by Copilot, but then I worked with it interactively to clean things up and gain a better understanding of how it all works.
