### PR TITLE
RST-13777 Add roscore_cpp launcher script and roslaunch integration [26.1.0]

### DIFF
--- a/tools/roslaunch/scripts/roscore_cpp
+++ b/tools/roslaunch/scripts/roscore_cpp
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2025, Locus Robotics
+# Copyright (c) 2026, Locus Robotics
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tools/roslaunch/scripts/roscore_cpp
+++ b/tools/roslaunch/scripts/roscore_cpp
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2025, Locus Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Locus Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+from optparse import OptionParser
+from rosmaster.master_api import NUM_WORKERS
+from roslaunch.nodeprocess import DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
+
+NAME = 'roscore_cpp'
+
+def _get_optparse():
+
+    parser = OptionParser(usage="usage: %prog [options]",
+                          prog=NAME,
+                          description="roscore_cpp will start up a C++ ROS Master, a ROS Parameter Server and a rosout logging node",
+                          epilog="See http://wiki.ros.org/roscore"
+                          )
+    parser.add_option("-p", "--port",
+                      dest="port", default=None,
+                      help="master port. Only valid if master is launched", metavar="PORT")
+    parser.add_option("-v", action="store_true",
+                      dest="verbose", default=False,
+                      help="verbose printing")
+    parser.add_option("-w", "--numworkers",
+                      dest="num_workers", default=NUM_WORKERS, type=int,
+                      help="override number of worker threads", metavar="NUM_WORKERS")
+    parser.add_option("-t", "--timeout",
+                      dest="timeout",
+                      help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
+    parser.add_option("--sigint-timeout",
+                      dest="sigint_timeout",
+                      default=DEFAULT_TIMEOUT_SIGINT, type=float,
+                      help="the SIGINT timeout used when killing the core (in seconds).",
+                      metavar="SIGINT_TIMEOUT")
+    parser.add_option("--sigterm-timeout",
+                      dest="sigterm_timeout",
+                      default=DEFAULT_TIMEOUT_SIGTERM, type=float,
+                      help="the SIGTERM timeout used when killing core if SIGINT does not stop the core (in seconds).",
+                      metavar="SIGTERM_TIMEOUT")
+    parser.add_option("--master-logger-level",
+                      dest="master_logger_level", default=False, type=str,
+                      help="set rosmaster logger level ('debug', 'info', 'warn', 'error', 'fatal')")
+    return parser
+
+
+parser = _get_optparse()
+(options, args) = parser.parse_args(sys.argv[1:])
+
+if len(args) > 0:
+    parser.error("roscore_cpp does not take arguments")
+
+
+import roslaunch
+roslaunch.main(['roscore_cpp', '--core', '--master-type', 'rosmaster_cpp'] + sys.argv[1:])

--- a/tools/roslaunch/setup.py
+++ b/tools/roslaunch/setup.py
@@ -5,6 +5,7 @@ d = generate_distutils_setup(
     packages=['roslaunch'],
     package_dir={'': 'src'},
     scripts=['scripts/roscore',
+             'scripts/roscore_cpp',
              'scripts/roslaunch',
              'scripts/roslaunch-complete',
              'scripts/roslaunch-deps',

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -204,6 +204,9 @@ def _get_optparse():
                       default=DEFAULT_TIMEOUT_SIGTERM, type=float,
                       help="the SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).",
                       metavar="SIGTERM_TIMEOUT")
+    parser.add_option("--master-type",
+                      dest="master_type", default=None, type=str,
+                      help="override master type (e.g. 'rosmaster_cpp' for the C++ master)")
 
     return parser
     
@@ -343,7 +346,8 @@ def main(argv=sys.argv):
                     show_summary=not options.no_summary,
                     force_required=options.force_required,
                     sigint_timeout=options.sigint_timeout,
-                    sigterm_timeout=options.sigterm_timeout)
+                    sigterm_timeout=options.sigterm_timeout,
+                    master_type=options.master_type)
             p.start()
             p.spin()
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -205,8 +205,9 @@ def _get_optparse():
                       help="the SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).",
                       metavar="SIGTERM_TIMEOUT")
     parser.add_option("--master-type",
-                      dest="master_type", default=None, type=str,
-                      help="override master type (e.g. 'rosmaster_cpp' for the C++ master)")
+                      dest="master_type", default=None,
+                      choices=[Master.ROSMASTER, Master.ROSMASTER_CPP],
+                      help="override master type ('rosmaster' or 'rosmaster_cpp' for the C++ master)")
 
     return parser
     

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -254,7 +254,8 @@ class Master(object):
     """
     __slots__ = ['type', 'auto', 'uri']
     ROSMASTER = 'rosmaster'
-    
+    ROSMASTER_CPP = 'rosmaster_cpp'
+
     # deprecated
     ZENMASTER = 'zenmaster'        
 

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -101,7 +101,7 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
             args += ['--master-logger-level', str(master_logger_level)]
     elif type_ == Master.ROSMASTER_CPP:
         package = 'rosmaster'
-        # Resolve full path to the C++ binary via rospkg
+        # Resolve full path to the C++ binary via roslib.packages.find_node
         import roslib.packages
         matches = roslib.packages.find_node(package, type_)
         if not matches:

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -99,6 +99,18 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
             args += ['-t', str(timeout)]
         if master_logger_level:
             args += ['--master-logger-level', str(master_logger_level)]
+    elif type_ == Master.ROSMASTER_CPP:
+        package = 'rosmaster'
+        # Resolve full path to the C++ binary via rospkg
+        import roslib.packages
+        matches = roslib.packages.find_node(package, type_)
+        if not matches:
+            raise RLException("Cannot locate C++ master binary [%s] in package [%s]" % (type_, package))
+        args = [matches[0], '--core', '-p', str(port), '-w', str(num_workers)]
+        if timeout is not None:
+            args += ['-t', str(timeout)]
+        if master_logger_level:
+            args += ['--master-logger-level', str(master_logger_level)]
     else:
         raise RLException("unknown master typ_: %s"%type_)
 

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -75,7 +75,8 @@ class ROSLaunchParent(object):
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
             verbose=False, force_screen=False, force_log=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False, show_summary=True, force_required=False,
-            sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
+            sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM,
+            master_type=None):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -146,6 +147,7 @@ class ROSLaunchParent(object):
         self.force_screen = force_screen
         self.force_log = force_log
         self.force_required = force_required
+        self.master_type = master_type
         
         # flag to prevent multiple shutdown attempts
         self._shutting_down = False
@@ -155,6 +157,9 @@ class ROSLaunchParent(object):
     def _load_config(self):
         self.config = roslaunch.config.load_config_default(self.roslaunch_files, self.port,
                 roslaunch_strs=self.roslaunch_strs, verbose=self.verbose)
+
+        if self.master_type:
+            self.config.master.type = self.master_type
 
         # #2370 (I really want to move this logic outside of parent)
         if self.force_screen:

--- a/tools/roslaunch/test/unit/test_nodeprocess.py
+++ b/tools/roslaunch/test/unit/test_nodeprocess.py
@@ -34,6 +34,7 @@
 import os
 import sys
 import unittest
+import unittest.mock
     
 import rospkg
 import roslib.packages
@@ -87,8 +88,44 @@ class TestNodeprocess(unittest.TestCase):
         self.assertRaises(RLException, create_master_process, run_id, type, ros_root, port, sigterm_timeout=0)
         
         # TODO: have to think more as to the correct environment for the master process
-        
-        
+
+    def test_create_master_process_cpp(self):
+        from roslaunch.core import Master, RLException
+        from roslaunch.nodeprocess import create_master_process, LocalProcess
+
+        ros_root = '/ros/root'
+        port = 1234
+        run_id = 'foo'
+
+        # When the binary cannot be found, RLException should be raised
+        with unittest.mock.patch('roslib.packages.find_node', return_value=[]) as mock_find:
+            self.assertRaises(
+                RLException,
+                create_master_process, run_id, Master.ROSMASTER_CPP, ros_root, port
+            )
+            mock_find.assert_called_once_with('rosmaster', Master.ROSMASTER_CPP)
+
+        fake_binary = '/opt/locusrobotics/hotdog/dev/ros1/lib/rosmaster_cpp/rosmaster_cpp'
+        with unittest.mock.patch('roslib.packages.find_node', return_value=[fake_binary]):
+            p = create_master_process(run_id, Master.ROSMASTER_CPP, ros_root, port)
+            self.assertIsInstance(p, LocalProcess)
+            self.assertEqual(p.args[0], fake_binary)
+            self.assertIn('--core', p.args)
+            idx = p.args.index('-p')
+            self.assertEqual(p.args[idx + 1], str(port))
+            self.assertEqual(p.package, 'rosmaster')
+
+        # timeout and master_logger_level args are forwarded
+        with unittest.mock.patch('roslib.packages.find_node', return_value=[fake_binary]):
+            p = create_master_process(run_id, Master.ROSMASTER_CPP, ros_root, port, timeout=5.0)
+            self.assertIn('-t', p.args)
+            self.assertIn('5.0', p.args)
+
+            p = create_master_process(run_id, Master.ROSMASTER_CPP, ros_root, port,
+                                      master_logger_level='debug')
+            self.assertIn('--master-logger-level', p.args)
+            self.assertIn('debug', p.args)
+
     def test_create_node_process(self):
         from roslaunch.core import Node, Machine, RLException
         from roslaunch.node_args import NodeParamsException

--- a/tools/rosmaster/test/master_integration.py
+++ b/tools/rosmaster/test/master_integration.py
@@ -1,0 +1,549 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2025, Locus Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Locus Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Shared utilities and test mixin classes for rosmaster integration tests.
+
+This module provides:
+  - MasterProcess: manages a rosmaster subprocess lifecycle
+  - Test mixin classes (CoreAPIMixin, ParamServerMixin, RegistrationsMixin)
+    containing test methods that work against any master implementation
+
+The mixin classes expect the following attributes on `self`:
+  self.proxy       - xmlrpc.client.ServerProxy connected to the master
+  self.master_port - port the master is listening on
+  self.master_uri  - full URI of the master
+"""
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import time
+import xmlrpc.client
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def find_free_port():
+    """Bind to port 0 and let the OS assign a free port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('localhost', 0))
+        return s.getsockname()[1]
+
+
+def wait_for_master(proxy, timeout=10.0):
+    """Poll the master until it responds to getPid."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            code, _, _ = proxy.getPid('/probe')
+            if code == 1:
+                return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    raise RuntimeError("Master did not become ready within %.1fs" % timeout)
+
+
+def find_python_master():
+    """Return the path to the Python rosmaster script."""
+    path = shutil.which('rosmaster')
+    if path:
+        return path
+    raise RuntimeError("Cannot find 'rosmaster' on PATH")
+
+
+def find_cpp_master():
+    """Return the path to the C++ rosmaster_cpp binary."""
+    try:
+        import roslib.packages
+        matches = roslib.packages.find_node('rosmaster', 'rosmaster_cpp')
+        if matches:
+            return matches[0]
+    except Exception:
+        pass
+    raise RuntimeError("Cannot find 'rosmaster_cpp' binary in rosmaster package")
+
+
+class MasterProcess:
+    """Context-managed rosmaster subprocess."""
+
+    def __init__(self, binary_path, port):
+        self.port = port
+        self.uri = 'http://localhost:%d/' % port
+        self.proc = subprocess.Popen(
+            [binary_path, '--core', '-p', str(port)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.proxy = xmlrpc.client.ServerProxy(self.uri)
+        wait_for_master(self.proxy)
+
+    def stop(self):
+        if self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGINT)
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Test Mixin: Core API
+# ---------------------------------------------------------------------------
+
+class CoreAPIMixin:
+
+    def test_get_pid(self):
+        code, _, pid = self.proxy.getPid('/test')
+        self.assertEqual(code, 1)
+        self.assertIsInstance(pid, int)
+        self.assertGreater(pid, 0)
+
+    def test_get_uri(self):
+        code, _, uri = self.proxy.getUri('/test')
+        self.assertEqual(code, 1)
+        self.assertTrue(uri.startswith('http://'))
+        self.assertIn(str(self.master_port), uri)
+
+
+# ---------------------------------------------------------------------------
+# Test Mixin: Parameter Server
+# ---------------------------------------------------------------------------
+
+class ParamServerMixin:
+
+    def _pname(self, suffix=''):
+        """Return a unique parameter name based on the current test method."""
+        return '/' + self._testMethodName + suffix
+
+    # -- basic types --------------------------------------------------------
+
+    def test_set_get_int(self):
+        key = self._pname()
+        code, _, _ = self.proxy.setParam('/test', key, 42)
+        self.assertEqual(code, 1)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, 42)
+
+    def test_set_get_string(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, 'hello world')
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, 'hello world')
+
+    def test_set_get_float(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, 3.14)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertAlmostEqual(val, 3.14, places=5)
+
+    def test_set_get_bool(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, True)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertTrue(val)
+        self.proxy.setParam('/test', key, False)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertFalse(val)
+
+    def test_set_get_list(self):
+        key = self._pname()
+        data = [1, 'two', 3.0, True]
+        self.proxy.setParam('/test', key, data)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, data)
+
+    def test_set_get_dict(self):
+        key = self._pname()
+        data = {'a': 1, 'b': 'hello', 'c': [1, 2]}
+        self.proxy.setParam('/test', key, data)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, data)
+
+    def test_set_get_nested_dict(self):
+        key = self._pname()
+        data = {'level1': {'level2': {'value': 42}}}
+        self.proxy.setParam('/test', key, data)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, data)
+
+    def test_set_get_empty_string(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, '')
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, '')
+
+    # -- has / delete / names -----------------------------------------------
+
+    def test_has_param(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, 1)
+        code, _, has = self.proxy.hasParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertTrue(has)
+
+    def test_has_param_missing(self):
+        code, _, has = self.proxy.hasParam('/test', '/nonexistent_xyz_has')
+        self.assertEqual(code, 1)
+        self.assertFalse(has)
+
+    def test_delete_param(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, 'to_delete')
+        code, _, _ = self.proxy.deleteParam('/test', key)
+        self.assertEqual(code, 1)
+        code, _, has = self.proxy.hasParam('/test', key)
+        self.assertFalse(has)
+
+    def test_delete_param_subtree(self):
+        """Deleting a namespace removes all children."""
+        ns = self._pname()
+        self.proxy.setParam('/test', ns + '/a', 1)
+        self.proxy.setParam('/test', ns + '/b', 2)
+        code, _, _ = self.proxy.deleteParam('/test', ns)
+        self.assertEqual(code, 1)
+        code, _, has = self.proxy.hasParam('/test', ns + '/a')
+        self.assertFalse(has)
+
+    def test_delete_param_missing(self):
+        code, _, _ = self.proxy.deleteParam('/test', '/nonexistent_xyz_del')
+        self.assertEqual(code, -1)
+
+    def test_get_param_names(self):
+        key = self._pname()
+        self.proxy.setParam('/test', key, 'val')
+        code, _, names = self.proxy.getParamNames('/test')
+        self.assertEqual(code, 1)
+        self.assertIn(key, names)
+
+    def test_get_param_missing(self):
+        code, _, _ = self.proxy.getParam('/test', '/nonexistent_xyz_get')
+        self.assertEqual(code, -1)
+
+    # -- namespaces and trees -----------------------------------------------
+
+    def test_param_namespace_tree(self):
+        """Set params in a namespace and retrieve as a dict tree."""
+        ns = self._pname()
+        self.proxy.setParam('/test', ns + '/x', 1)
+        self.proxy.setParam('/test', ns + '/y', 2)
+        self.proxy.setParam('/test', ns + '/z', 3)
+        code, _, tree = self.proxy.getParam('/test', ns)
+        self.assertEqual(code, 1)
+        self.assertIsInstance(tree, dict)
+        self.assertEqual(tree['x'], 1)
+        self.assertEqual(tree['y'], 2)
+        self.assertEqual(tree['z'], 3)
+
+    def test_search_param(self):
+        """searchParam walks up the namespace tree."""
+        key = self._pname()
+        self.proxy.setParam('/test', key, 'found')
+        # Search from a deep namespace — should find it at root
+        code, _, found_key = self.proxy.searchParam('/deep/ns/node', key.lstrip('/'))
+        self.assertEqual(code, 1)
+        self.assertEqual(found_key, key)
+
+    def test_search_param_not_found(self):
+        code, _, _ = self.proxy.searchParam('/test', 'nonexistent_search_xyz')
+        self.assertEqual(code, -1)
+
+    # -- overwrite ----------------------------------------------------------
+
+    def test_param_overwrite_type(self):
+        """Overwriting a param with a different type should succeed."""
+        key = self._pname()
+        self.proxy.setParam('/test', key, 42)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(val, 42)
+
+        self.proxy.setParam('/test', key, 'now_a_string')
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, 'now_a_string')
+
+    def test_param_overwrite_dict_with_scalar(self):
+        """Overwriting a dict namespace with a scalar should work."""
+        key = self._pname()
+        self.proxy.setParam('/test', key, {'a': 1, 'b': 2})
+        self.proxy.setParam('/test', key, 99)
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, 99)
+
+    # -- subscribe / unsubscribe --------------------------------------------
+
+    def test_subscribe_param(self):
+        """subscribeParam should return the current value."""
+        key = self._pname()
+        self.proxy.setParam('/test', key, 'current')
+        code, _, val = self.proxy.subscribeParam(
+            '/caller', 'http://localhost:12345', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, 'current')
+
+    def test_subscribe_param_nonexistent(self):
+        """subscribeParam for a key that doesn't exist should return an empty dict, not crash."""
+        key = self._pname()
+        code, _, val = self.proxy.subscribeParam(
+            '/caller', 'http://localhost:12345', key)
+        self.assertEqual(code, 1)
+        self.assertIsInstance(val, dict)
+        # Must not contain internal sentinel keys
+        for k in val:
+            self.assertNotIn(k, ('__placeholder__', '__init__', '__empty__'))
+
+    def test_get_param_dict_no_sentinels(self):
+        """getParam on a dict must not leak internal sentinel keys."""
+        key = self._pname()
+        self.proxy.setParam('/test', key, {'a': 1, 'b': 2})
+        code, _, val = self.proxy.getParam('/test', key)
+        self.assertEqual(code, 1)
+        self.assertEqual(val, {'a': 1, 'b': 2})
+        for k in val:
+            self.assertNotIn(k, ('__placeholder__', '__init__', '__empty__'))
+
+    def test_get_param_after_delete_sibling_no_sentinels(self):
+        """After deleting one child, the parent dict must not contain sentinel keys."""
+        base = self._pname()
+        self.proxy.setParam('/test', base + '/child1', 'v1')
+        self.proxy.setParam('/test', base + '/child2', 'v2')
+        self.proxy.deleteParam('/test', base + '/child1')
+        code, _, val = self.proxy.getParam('/test', base)
+        self.assertEqual(code, 1)
+        self.assertIn('child2', val)
+        for k in val:
+            self.assertNotIn(k, ('__placeholder__', '__init__', '__empty__'))
+
+    def test_unsubscribe_param(self):
+        key = self._pname()
+        self.proxy.subscribeParam('/caller', 'http://localhost:12345', key)
+        code, _, count = self.proxy.unsubscribeParam(
+            '/caller', 'http://localhost:12345', key)
+        self.assertEqual(code, 1)
+
+
+# ---------------------------------------------------------------------------
+# Test Mixin: Registrations
+# ---------------------------------------------------------------------------
+
+class RegistrationsMixin:
+
+    def _node(self, name='node1'):
+        return '/' + self._testMethodName + '_' + name
+
+    def _topic(self, name='topic1'):
+        return '/' + self._testMethodName + '_' + name
+
+    def _service(self, name='srv1'):
+        return '/' + self._testMethodName + '_' + name
+
+    def _api(self, port=12345):
+        return 'http://localhost:%d/' % port
+
+    # -- publishers ---------------------------------------------------------
+
+    def test_register_publisher(self):
+        code, _, subs = self.proxy.registerPublisher(
+            self._node(), self._topic(), 'std_msgs/String', self._api())
+        self.assertEqual(code, 1)
+        self.assertIsInstance(subs, list)
+
+    def test_unregister_publisher(self):
+        node, topic, api = self._node(), self._topic(), self._api()
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', api)
+        code, _, count = self.proxy.unregisterPublisher(node, topic, api)
+        self.assertEqual(code, 1)
+
+    # -- subscribers --------------------------------------------------------
+
+    def test_register_subscriber(self):
+        code, _, pubs = self.proxy.registerSubscriber(
+            self._node(), self._topic(), 'std_msgs/String', self._api())
+        self.assertEqual(code, 1)
+        self.assertIsInstance(pubs, list)
+
+    def test_unregister_subscriber(self):
+        node, topic, api = self._node(), self._topic(), self._api()
+        self.proxy.registerSubscriber(node, topic, 'std_msgs/String', api)
+        code, _, count = self.proxy.unregisterSubscriber(node, topic, api)
+        self.assertEqual(code, 1)
+
+    # -- services -----------------------------------------------------------
+
+    def test_register_service(self):
+        code, _, _ = self.proxy.registerService(
+            self._node(), self._service(), 'rosrpc://localhost:9999', self._api())
+        self.assertEqual(code, 1)
+
+    def test_unregister_service(self):
+        node, svc = self._node(), self._service()
+        self.proxy.registerService(node, svc, 'rosrpc://localhost:9999', self._api())
+        code, _, count = self.proxy.unregisterService(
+            node, svc, 'rosrpc://localhost:9999')
+        self.assertEqual(code, 1)
+
+    # -- lookups ------------------------------------------------------------
+
+    def test_lookup_node(self):
+        node, topic = self._node(), self._topic()
+        api = self._api(23456)
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', api)
+        code, _, uri = self.proxy.lookupNode('/test', node)
+        self.assertEqual(code, 1)
+        self.assertEqual(uri, api)
+
+    def test_lookup_node_missing(self):
+        code, _, _ = self.proxy.lookupNode('/test', '/nonexistent_node_xyz')
+        self.assertEqual(code, -1)
+
+    def test_lookup_service(self):
+        node, svc = self._node(), self._service()
+        svc_api = 'rosrpc://localhost:8888'
+        self.proxy.registerService(node, svc, svc_api, self._api())
+        code, _, uri = self.proxy.lookupService('/test', svc)
+        self.assertEqual(code, 1)
+        self.assertEqual(uri, svc_api)
+
+    def test_lookup_service_missing(self):
+        code, _, _ = self.proxy.lookupService('/test', '/nonexistent_svc_xyz')
+        self.assertEqual(code, -1)
+
+    # -- graph queries ------------------------------------------------------
+
+    def test_get_published_topics(self):
+        node, topic = self._node(), self._topic()
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', self._api())
+        code, _, topics = self.proxy.getPublishedTopics('/test', '')
+        self.assertEqual(code, 1)
+        topic_names = [t[0] for t in topics]
+        self.assertIn(topic, topic_names)
+
+    def test_get_topic_types(self):
+        node, topic = self._node(), self._topic()
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', self._api())
+        code, _, types = self.proxy.getTopicTypes('/test')
+        self.assertEqual(code, 1)
+        type_dict = {t[0]: t[1] for t in types}
+        self.assertIn(topic, type_dict)
+        self.assertEqual(type_dict[topic], 'std_msgs/String')
+
+    def test_get_system_state(self):
+        node, topic, svc = self._node(), self._topic(), self._service()
+        api = self._api(34567)
+        sub_node = self._node('sub')
+        sub_api = self._api(34568)
+
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', api)
+        self.proxy.registerSubscriber(sub_node, topic, 'std_msgs/String', sub_api)
+        self.proxy.registerService(node, svc, 'rosrpc://localhost:7777', api)
+
+        code, _, state = self.proxy.getSystemState('/test')
+        self.assertEqual(code, 1)
+        self.assertEqual(len(state), 3)
+        pubs, subs, services = state
+
+        pub_dict = {e[0]: e[1] for e in pubs}
+        self.assertIn(topic, pub_dict)
+        self.assertIn(node, pub_dict[topic])
+
+        sub_dict = {e[0]: e[1] for e in subs}
+        self.assertIn(topic, sub_dict)
+        self.assertIn(sub_node, sub_dict[topic])
+
+        svc_dict = {e[0]: e[1] for e in services}
+        self.assertIn(svc, svc_dict)
+
+    # -- cross-registration -------------------------------------------------
+
+    def test_register_publisher_returns_subscribers(self):
+        """registerPublisher should return the list of existing subscriber APIs."""
+        topic = self._topic()
+        sub_api = self._api(45678)
+        self.proxy.registerSubscriber(
+            self._node('sub'), topic, 'std_msgs/String', sub_api)
+        code, _, subs = self.proxy.registerPublisher(
+            self._node('pub'), topic, 'std_msgs/String', self._api(45679))
+        self.assertEqual(code, 1)
+        self.assertIn(sub_api, subs)
+
+    def test_register_subscriber_returns_publishers(self):
+        """registerSubscriber should return the list of existing publisher APIs."""
+        topic = self._topic()
+        pub_api = self._api(56789)
+        self.proxy.registerPublisher(
+            self._node('pub'), topic, 'std_msgs/String', pub_api)
+        code, _, pubs = self.proxy.registerSubscriber(
+            self._node('sub'), topic, 'std_msgs/String', self._api(56790))
+        self.assertEqual(code, 1)
+        self.assertIn(pub_api, pubs)
+
+    def test_node_reregistration(self):
+        """Re-registering a node with a new API URI should update lookupNode."""
+        node, topic = self._node(), self._topic()
+        old_api = self._api(11111)
+        new_api = self._api(22222)
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', old_api)
+        self.proxy.registerPublisher(node, topic, 'std_msgs/String', new_api)
+        code, _, uri = self.proxy.lookupNode('/test', node)
+        self.assertEqual(code, 1)
+        self.assertEqual(uri, new_api)
+
+    def test_get_published_topics_with_subgraph(self):
+        """getPublishedTopics with a subgraph filter."""
+        node = self._node()
+        t1 = '/' + self._testMethodName + '/ns/topic_a'
+        t2 = '/' + self._testMethodName + '/other/topic_b'
+        self.proxy.registerPublisher(node, t1, 'std_msgs/String', self._api(61111))
+        self.proxy.registerPublisher(node, t2, 'std_msgs/String', self._api(61111))
+
+        code, _, topics = self.proxy.getPublishedTopics(
+            '/test', '/' + self._testMethodName + '/ns')
+        self.assertEqual(code, 1)
+        topic_names = [t[0] for t in topics]
+        self.assertIn(t1, topic_names)
+        self.assertNotIn(t2, topic_names)

--- a/tools/rosmaster/test/perf_benchmark.py
+++ b/tools/rosmaster/test/perf_benchmark.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2025, Locus Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Locus Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Performance benchmarks for rosmaster: Python vs C++.
+
+Simulates a large fleet of robots, each with many topics and services,
+then measures the latency of key XML-RPC API calls that underpin
+commands like `rostopic list` and `rosservice list`.
+
+Usage:
+    python3 perf_benchmark.py [--robots N] [--topics-per-robot N] [--services-per-robot N]
+
+Runs both masters back-to-back and prints a comparison table.
+"""
+
+import argparse
+import signal
+import socket
+import subprocess
+import statistics
+import sys
+import time
+import xmlrpc.client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('localhost', 0))
+        return s.getsockname()[1]
+
+
+def wait_for_master(proxy, timeout=10.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            code, _, _ = proxy.getPid('/probe')
+            if code == 1:
+                return
+        except Exception:
+            pass
+        time.sleep(0.05)
+    raise RuntimeError("Master did not start within %.1fs" % timeout)
+
+
+def find_python_master():
+    import shutil
+    path = shutil.which('rosmaster')
+    if path:
+        return path
+    raise RuntimeError("Cannot find 'rosmaster' on PATH")
+
+
+def find_cpp_master():
+    import roslib.packages
+    matches = roslib.packages.find_node('rosmaster', 'rosmaster_cpp')
+    if matches:
+        return matches[0]
+    raise RuntimeError("Cannot find 'rosmaster_cpp'")
+
+
+class MasterProcess:
+    def __init__(self, binary, port):
+        self.port = port
+        self.proc = subprocess.Popen(
+            [binary, '--core', '-p', str(port)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.proxy = xmlrpc.client.ServerProxy('http://localhost:%d/' % port)
+        wait_for_master(self.proxy)
+
+    def stop(self):
+        if self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGINT)
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Population & Benchmarking
+# ---------------------------------------------------------------------------
+
+def populate(proxy, num_robots, topics_per_robot, services_per_robot):
+    """Register a simulated fleet of robots."""
+    for r in range(num_robots):
+        node = '/robot_%04d/autonomy' % r
+        api = 'http://localhost:%d/' % (20000 + r)
+
+        for t in range(topics_per_robot):
+            topic = '/robot_%04d/topic_%03d' % (r, t)
+            proxy.registerPublisher(node, topic, 'std_msgs/String', api)
+
+        for s in range(services_per_robot):
+            svc = '/robot_%04d/service_%03d' % (r, s)
+            proxy.registerService(node, svc, 'rosrpc://localhost:%d' % (30000 + r), api)
+
+    # Also register a few subscribers to make getSystemState richer
+    for r in range(num_robots):
+        sub_node = '/robot_%04d/navigator' % r
+        sub_api = 'http://localhost:%d/' % (40000 + r)
+        # Each robot subscribes to a handful of topics from other robots
+        for t in range(min(3, topics_per_robot)):
+            other = (r + 1) % num_robots
+            topic = '/robot_%04d/topic_%03d' % (other, t)
+            proxy.registerSubscriber(sub_node, topic, 'std_msgs/String', sub_api)
+
+
+def populate_params(proxy, num_robots, params_per_robot):
+    """Set parameters simulating robot configuration."""
+    for r in range(num_robots):
+        for p in range(params_per_robot):
+            key = '/robot_%04d/param_%03d' % (r, p)
+            proxy.setParam('/config', key, 'value_%d_%d' % (r, p))
+
+
+def benchmark_call(proxy, method, args, iterations=20):
+    """Time repeated XML-RPC calls. Returns list of durations in ms."""
+    func = getattr(proxy, method)
+    # Warm up
+    for _ in range(3):
+        func(*args)
+
+    times = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        func(*args)
+        t1 = time.perf_counter()
+        times.append((t1 - t0) * 1000.0)
+    return times
+
+
+def run_benchmarks(proxy, label, iterations=20):
+    """Run all benchmark scenarios and return results dict."""
+    results = {}
+
+    # --- rostopic list: getSystemState + getTopicTypes ---
+    times = benchmark_call(proxy, 'getSystemState', ('/bench',), iterations)
+    results['getSystemState'] = times
+
+    times = benchmark_call(proxy, 'getTopicTypes', ('/bench',), iterations)
+    results['getTopicTypes'] = times
+
+    # Combined: simulates `rostopic list`
+    combined = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        proxy.getSystemState('/bench')
+        proxy.getTopicTypes('/bench')
+        t1 = time.perf_counter()
+        combined.append((t1 - t0) * 1000.0)
+    results['rostopic_list (combined)'] = combined
+
+    # --- rosservice list: getSystemState (same call, included for clarity) ---
+
+    # --- Parameter server ---
+    times = benchmark_call(proxy, 'getParamNames', ('/bench',), iterations)
+    results['getParamNames'] = times
+
+    # --- getPublishedTopics ---
+    times = benchmark_call(proxy, 'getPublishedTopics', ('/bench', ''), iterations)
+    results['getPublishedTopics'] = times
+
+    # --- Single lookups (constant-time sanity check) ---
+    times = benchmark_call(proxy, 'lookupNode', ('/bench', '/robot_0000/autonomy'), iterations)
+    results['lookupNode'] = times
+
+    times = benchmark_call(proxy, 'lookupService', ('/bench', '/robot_0000/service_000'), iterations)
+    results['lookupService'] = times
+
+    return results
+
+
+def run_registration_benchmarks(binary, num_registrations, iterations=5):
+    """Benchmark bulk registration throughput on a fresh master per iteration.
+
+    Simulates a multimaster_fkie sync burst: many registerPublisher,
+    registerSubscriber, and registerService calls in rapid succession.
+    Returns dict of operation -> list of elapsed milliseconds (floats).
+    """
+    results = {
+        'registerPublisher': [],
+        'registerSubscriber': [],
+        'registerService': [],
+        'mixed sync burst': [],
+    }
+
+    for _ in range(iterations):
+        port = find_free_port()
+        master = MasterProcess(binary, port)
+        proxy = master.proxy
+
+        # registerPublisher burst
+        t0 = time.perf_counter()
+        for i in range(num_registrations):
+            proxy.registerPublisher(
+                '/node_%04d' % i, '/topic_%04d' % i,
+                'std_msgs/String', 'http://localhost:%d/' % (20000 + i))
+        elapsed = (time.perf_counter() - t0) * 1000.0
+        results['registerPublisher'].append(elapsed)
+
+        master.stop()
+
+        # registerSubscriber burst
+        port = find_free_port()
+        master = MasterProcess(binary, port)
+        proxy = master.proxy
+
+        t0 = time.perf_counter()
+        for i in range(num_registrations):
+            proxy.registerSubscriber(
+                '/node_%04d' % i, '/topic_%04d' % i,
+                'std_msgs/String', 'http://localhost:%d/' % (20000 + i))
+        elapsed = (time.perf_counter() - t0) * 1000.0
+        results['registerSubscriber'].append(elapsed)
+
+        master.stop()
+
+        # registerService burst
+        port = find_free_port()
+        master = MasterProcess(binary, port)
+        proxy = master.proxy
+
+        t0 = time.perf_counter()
+        for i in range(num_registrations):
+            proxy.registerService(
+                '/node_%04d' % i, '/svc_%04d' % i,
+                'rosrpc://localhost:%d' % (30000 + i),
+                'http://localhost:%d/' % (20000 + i))
+        elapsed = (time.perf_counter() - t0) * 1000.0
+        results['registerService'].append(elapsed)
+
+        master.stop()
+
+        # Mixed burst: simulates a real sync event
+        # (pubs + subs + services interleaved, like multimaster_fkie would do)
+        port = find_free_port()
+        master = MasterProcess(binary, port)
+        proxy = master.proxy
+
+        count = num_registrations // 3
+        t0 = time.perf_counter()
+        for i in range(count):
+            proxy.registerPublisher(
+                '/sync_%04d' % i, '/topic_%04d' % i,
+                'std_msgs/String', 'http://localhost:%d/' % (20000 + i))
+            proxy.registerSubscriber(
+                '/sync_%04d' % i, '/sub_topic_%04d' % i,
+                'std_msgs/String', 'http://localhost:%d/' % (20000 + i))
+            proxy.registerService(
+                '/sync_%04d' % i, '/svc_%04d' % i,
+                'rosrpc://localhost:%d' % (30000 + i),
+                'http://localhost:%d/' % (20000 + i))
+        elapsed = (time.perf_counter() - t0) * 1000.0
+        results['mixed sync burst'].append(elapsed)
+
+        master.stop()
+
+    return results
+
+
+def print_registration_results(py_reg, cpp_reg, num_registrations):
+    print("\n" + "=" * 82)
+    print("  REGISTRATION THROUGHPUT BENCHMARK  (%d registrations per burst)" % num_registrations)
+    print("=" * 82)
+    print("  %-25s  %16s  %16s  %9s" % ("Operation", "Python (ms)", "C++ (ms)", "Speedup"))
+    print("  " + "-" * 78)
+
+    for op in py_reg:
+        py_med, py_sd = fmt_stats(py_reg[op])
+        cpp_med, cpp_sd = fmt_stats(cpp_reg[op])
+        speedup = py_med / cpp_med if cpp_med > 0 else float('inf')
+        n = num_registrations if 'mixed' not in op else (num_registrations // 3) * 3
+        py_ops = n / (py_med / 1000.0)
+        cpp_ops = n / (cpp_med / 1000.0)
+        print("  %-25s  %6.1f ± %6.1f  %6.1f ± %6.1f  %7.1fx"
+              % (op, py_med, py_sd, cpp_med, cpp_sd, speedup))
+        print("  %25s  %10.0f op/s  %10.0f op/s" % ('', py_ops, cpp_ops))
+
+    print("=" * 82)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def fmt_stats(times):
+    """Format timing stats: median ± stdev."""
+    med = statistics.median(times)
+    sd = statistics.stdev(times) if len(times) > 1 else 0.0
+    return med, sd
+
+
+def print_results(py_results, cpp_results, num_topics, num_services, num_params):
+    total = num_topics + num_services + num_params
+    print("\n" + "=" * 82)
+    print("  ROSMASTER PERFORMANCE BENCHMARK")
+    print("  Topics: %d  |  Services: %d  |  Params: %d  |  Total registrations: %d"
+          % (num_topics, num_services, num_params, total))
+    print("=" * 82)
+    print("  %-30s  %14s  %14s  %9s" % ("Method", "Python (ms)", "C++ (ms)", "Speedup"))
+    print("  " + "-" * 78)
+
+    for method in py_results:
+        py_med, py_sd = fmt_stats(py_results[method])
+        cpp_med, cpp_sd = fmt_stats(cpp_results[method])
+        speedup = py_med / cpp_med if cpp_med > 0 else float('inf')
+        print("  %-30s  %6.2f ± %5.2f  %6.2f ± %5.2f  %7.1fx"
+              % (method, py_med, py_sd, cpp_med, cpp_sd, speedup))
+
+    print("=" * 82)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description='Rosmaster performance benchmark')
+    parser.add_argument('--robots', type=int, default=100,
+                        help='Number of simulated robots (default: 100)')
+    parser.add_argument('--topics-per-robot', type=int, default=20,
+                        help='Topics per robot (default: 20)')
+    parser.add_argument('--services-per-robot', type=int, default=5,
+                        help='Services per robot (default: 5)')
+    parser.add_argument('--params-per-robot', type=int, default=10,
+                        help='Params per robot (default: 10)')
+    parser.add_argument('--iterations', type=int, default=20,
+                        help='Iterations per benchmark call (default: 20)')
+    parser.add_argument('--reg-burst', type=int, default=1000,
+                        help='Registrations per burst in throughput test (default: 1000)')
+    parser.add_argument('--reg-iterations', type=int, default=5,
+                        help='Iterations for registration throughput test (default: 5)')
+    args = parser.parse_args()
+
+    num_topics = args.robots * args.topics_per_robot
+    num_services = args.robots * args.services_per_robot
+    num_params = args.robots * args.params_per_robot
+
+    print("Benchmark config: %d robots × (%d topics + %d services + %d params) = %d total"
+          % (args.robots, args.topics_per_robot, args.services_per_robot,
+             args.params_per_robot, num_topics + num_services + num_params))
+
+    # --- Python master ---
+    print("\n[1/4] Starting Python master...")
+    py_port = find_free_port()
+    py_master = MasterProcess(find_python_master(), py_port)
+
+    print("[2/4] Populating Python master (%d topics, %d services, %d params)..."
+          % (num_topics, num_services, num_params))
+    populate(py_master.proxy, args.robots, args.topics_per_robot, args.services_per_robot)
+    populate_params(py_master.proxy, args.robots, args.params_per_robot)
+    print("       Running benchmarks...")
+    py_results = run_benchmarks(py_master.proxy, 'Python', args.iterations)
+    py_master.stop()
+
+    # --- C++ master ---
+    print("[3/4] Starting C++ master...")
+    cpp_port = find_free_port()
+    cpp_master = MasterProcess(find_cpp_master(), cpp_port)
+
+    print("[4/4] Populating C++ master (%d topics, %d services, %d params)..."
+          % (num_topics, num_services, num_params))
+    populate(cpp_master.proxy, args.robots, args.topics_per_robot, args.services_per_robot)
+    populate_params(cpp_master.proxy, args.robots, args.params_per_robot)
+    print("       Running benchmarks...")
+    cpp_results = run_benchmarks(cpp_master.proxy, 'C++', args.iterations)
+    cpp_master.stop()
+
+    # --- Report ---
+    print_results(py_results, cpp_results, num_topics, num_services, num_params)
+
+    # --- Registration throughput ---
+    py_binary = find_python_master()
+    cpp_binary = find_cpp_master()
+
+    print("[5/6] Registration throughput: Python master (%d registrations × %d iterations)..."
+          % (args.reg_burst, args.reg_iterations))
+    py_reg = run_registration_benchmarks(py_binary, args.reg_burst, args.reg_iterations)
+
+    print("[6/6] Registration throughput: C++ master (%d registrations × %d iterations)..."
+          % (args.reg_burst, args.reg_iterations))
+    cpp_reg = run_registration_benchmarks(cpp_binary, args.reg_burst, args.reg_iterations)
+
+    print_registration_results(py_reg, cpp_reg, args.reg_burst)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/rosmaster/test/test_integration_cpp.py
+++ b/tools/rosmaster/test/test_integration_cpp.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2025, Locus Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Locus Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests that exercise the C++ rosmaster_cpp via XML-RPC."""
+
+import os
+import socket
+import sys
+import unittest
+
+# Ensure the test directory is on sys.path so master_integration can be found
+# regardless of the working directory (e.g., when run by nose in CI).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from master_integration import (
+    CoreAPIMixin,
+    MasterProcess,
+    ParamServerMixin,
+    RegistrationsMixin,
+    find_cpp_master,
+    find_free_port,
+)
+
+socket.setdefaulttimeout(5.0)
+
+_master = None
+_skip_reason = None
+_saved_timeout = None
+
+try:
+    _cpp_binary = find_cpp_master()
+except RuntimeError as e:
+    _cpp_binary = None
+    _skip_reason = str(e)
+
+
+def setup_module():
+    global _master, _saved_timeout
+    if _cpp_binary is None:
+        raise unittest.SkipTest(_skip_reason)
+    _saved_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(5.0)
+    _master = MasterProcess(_cpp_binary, find_free_port())
+
+
+def teardown_module():
+    global _master, _saved_timeout
+    if _master:
+        _master.stop()
+        _master = None
+    if _saved_timeout is not None:
+        socket.setdefaulttimeout(_saved_timeout)
+
+
+# Aliases for unittest compatibility (e.g. when running via `python -m unittest`)
+setUpModule = setup_module
+tearDownModule = teardown_module
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        if _master is None:
+            self.skipTest('C++ master not available')
+        self.proxy = _master.proxy
+        self.master_port = _master.port
+        self.master_uri = _master.uri
+
+
+class TestCppCoreAPI(_Base, CoreAPIMixin):
+    pass
+
+
+class TestCppParamServer(_Base, ParamServerMixin):
+    pass
+
+
+class TestCppRegistrations(_Base, RegistrationsMixin):
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/rosmaster/test/test_integration_python.py
+++ b/tools/rosmaster/test/test_integration_python.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2025, Locus Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Locus Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests that exercise the Python rosmaster via XML-RPC."""
+
+import os
+import socket
+import sys
+import unittest
+
+# Ensure the test directory is on sys.path so master_integration can be found
+# regardless of the working directory (e.g., when run by nose in CI).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from master_integration import (
+    CoreAPIMixin,
+    MasterProcess,
+    ParamServerMixin,
+    RegistrationsMixin,
+    find_free_port,
+    find_python_master,
+)
+
+_master = None
+_saved_timeout = None
+
+
+def setup_module():
+    global _master, _saved_timeout
+    _saved_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(5.0)
+    _master = MasterProcess(find_python_master(), find_free_port())
+
+
+def teardown_module():
+    global _master, _saved_timeout
+    if _master:
+        _master.stop()
+        _master = None
+    socket.setdefaulttimeout(_saved_timeout)
+
+
+# Aliases for unittest compatibility (e.g. when running via `python -m unittest`)
+setUpModule = setup_module
+tearDownModule = teardown_module
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.proxy = _master.proxy
+        self.master_port = _master.port
+        self.master_uri = _master.uri
+
+
+class TestPythonCoreAPI(_Base, CoreAPIMixin):
+    pass
+
+
+class TestPythonParamServer(_Base, ParamServerMixin):
+    pass
+
+
+class TestPythonRegistrations(_Base, RegistrationsMixin):
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utilities/xmlrpcpp/test/xmlrpc_bench.cpp
+++ b/utilities/xmlrpcpp/test/xmlrpc_bench.cpp
@@ -1,3 +1,35 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2025, Locus Robotics
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Locus Robotics nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 /*
  * xmlrpcpp serialization micro-benchmark
  *


### PR DESCRIPTION
The next PR in the C++ ROS master chain. This one is just about enabling us to run the new C++ version in the same way that we run the python version.

*Copilot was used to generate this code*, but I have reviewed it, and it's been tested thoroughly on the dev floor for a couple months now.

----

Wire the C++ rosmaster binary into roslaunch so it can be started with the `roscore_cpp` command, mirroring the existing `roscore`:

- scripts/roscore_cpp: Launcher script that passes --master-type=cpp
- core.py: Add Master.ROSMASTER_CPP type enum
- nodeprocess.py: Handle ROSMASTER_CPP in create_master_process(), resolve binary path via roslib.packages.find_node()
- parent.py: Thread master_type through ROSLaunchParent
- __init__.py: Add --master-type CLI option
- setup.py: Register roscore_cpp as console script
